### PR TITLE
✨ feat: FCM 토큰 저장 및 푸시 알림 기능 구현 #9

### DIFF
--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/converter/AttendanceConverter.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/converter/AttendanceConverter.java
@@ -4,6 +4,7 @@ import com.project.smunionbe.domain.club.entity.Club;
 import com.project.smunionbe.domain.notification.attendance.dto.request.AttendanceReqDTO;
 import com.project.smunionbe.domain.notification.attendance.dto.response.AttendanceResDTO;
 import com.project.smunionbe.domain.notification.attendance.entity.AttendanceNotice;
+import com.project.smunionbe.domain.notification.fcm.dto.request.FCMReqDTO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -36,5 +37,14 @@ public class AttendanceConverter {
                 notice.getDate(),
                 notice.getCreatedAt()
         );
+    }
+
+    // FCM 알림 전송 DTO 생성 메서드
+    public static FCMReqDTO.FCMSendDTO toSendDTO(String fcmToken, AttendanceNotice attendanceNotice) {
+        return FCMReqDTO.FCMSendDTO.builder()
+                .fcmToken(fcmToken)
+                .title(attendanceNotice.getTitle())  // 공지 제목
+                .body(attendanceNotice.getContent()) // 공지 내용
+                .build();
     }
 }

--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/service/command/AttendanceCommandService.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/service/command/AttendanceCommandService.java
@@ -1,11 +1,9 @@
 package com.project.smunionbe.domain.notification.attendance.service.command;
 
 import com.project.smunionbe.domain.club.entity.Club;
-import com.project.smunionbe.domain.club.entity.Department;
 import com.project.smunionbe.domain.club.repository.ClubRepository;
 import com.project.smunionbe.domain.member.entity.MemberClub;
 import com.project.smunionbe.domain.member.repository.MemberClubRepository;
-import com.project.smunionbe.domain.member.repository.MemberRepository;
 import com.project.smunionbe.domain.notification.attendance.converter.AttendanceConverter;
 import com.project.smunionbe.domain.notification.attendance.dto.request.AttendanceReqDTO;
 import com.project.smunionbe.domain.notification.attendance.entity.AttendanceNotice;
@@ -14,9 +12,9 @@ import com.project.smunionbe.domain.notification.attendance.exception.Attendance
 import com.project.smunionbe.domain.notification.attendance.exception.AttendanceException;
 import com.project.smunionbe.domain.notification.attendance.repository.AttendanceRepository;
 import com.project.smunionbe.domain.notification.attendance.repository.AttendanceStatusRepository;
+import com.project.smunionbe.domain.notification.attendance.service.event.FCMNotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,9 +28,9 @@ public class AttendanceCommandService {
 
     private final AttendanceRepository attendanceRepository;
     private final ClubRepository clubRepository;
-    private final MemberRepository memberRepository;
     private final MemberClubRepository memberClubRepository;
     private final AttendanceStatusRepository attendanceStatusRepository;
+    private final FCMNotificationService fcmNotificationService;
 
     public void createAttendance(AttendanceReqDTO.CreateAttendanceDTO request, Long memberId) {
         // 1. 권한 확인
@@ -69,6 +67,9 @@ public class AttendanceCommandService {
                         .build())
                 .toList();
         attendanceStatusRepository.saveAll(attendanceStatuses);
+
+        // 6. 푸시 알림 전송 (FCMNotificationService 사용)
+        fcmNotificationService.sendPushNotifications(attendanceNotice, membersInTargetDepartments);
     }
 
     public void updateAttendance(Long attendanceId, AttendanceReqDTO.UpdateAttendanceRequest request, Long memberId) {

--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/service/event/FCMNotificationService.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/service/event/FCMNotificationService.java
@@ -1,0 +1,49 @@
+package com.project.smunionbe.domain.notification.attendance.service.event;
+
+import com.project.smunionbe.domain.member.entity.MemberClub;
+import com.project.smunionbe.domain.notification.attendance.converter.AttendanceConverter;
+import com.project.smunionbe.domain.notification.attendance.entity.AttendanceNotice;
+import com.project.smunionbe.domain.notification.fcm.dto.request.FCMReqDTO;
+import com.project.smunionbe.domain.notification.fcm.service.command.FCMService;
+import com.project.smunionbe.domain.notification.fcm.service.command.FCMTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FCMNotificationService {
+
+    private final FCMService fcmService;
+    private final FCMTokenService fcmTokenService;
+
+    /**
+     * 멤버들에게 FCM 푸시 알림을 전송하는 메서드
+     */
+    public void sendPushNotifications(AttendanceNotice attendanceNotice, List<MemberClub> targetMembers) {
+        for (MemberClub member : targetMembers) {
+            // Redis에서 FCM 토큰 조회
+            String fcmToken = fcmTokenService.getFcmToken(member.getMember().getEmail());
+
+            // FCM 토큰이 없으면 푸시 알림 건너뛰기
+            if (fcmToken == null || fcmToken.isEmpty()) {
+                log.warn("사용자 {}의 FCM 토큰이 존재하지 않아 푸시 알림을 건너뜁니다.", member.getMember().getEmail());
+                continue;
+            }
+
+            // FCM 알림 생성
+            FCMReqDTO.FCMSendDTO fcmSendDTO = AttendanceConverter.toSendDTO(fcmToken, attendanceNotice);
+
+            // FCM 푸시 알림 전송
+            try {
+                fcmService.sendFcmNotification(fcmSendDTO);
+                log.info("사용자 {}에게 푸시 알림 전송 성공", member.getMember().getEmail());
+            } catch (Exception e) {
+                log.error("사용자 {}에게 푸시 알림 전송 실패: {}", member.getMember().getEmail(), e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/controller/FCMController.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/controller/FCMController.java
@@ -1,0 +1,37 @@
+package com.project.smunionbe.domain.notification.fcm.controller;
+
+import com.project.smunionbe.domain.notification.fcm.dto.request.FCMReqDTO;
+import com.project.smunionbe.domain.notification.fcm.service.command.FCMService;
+import com.project.smunionbe.domain.notification.fcm.service.command.FCMTokenService;
+import com.project.smunionbe.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/notices")
+@RequiredArgsConstructor
+@Tag(name = "푸시 알림 관련 API", description = "푸시 알림 관련 API입니다.")
+public class FCMController {
+
+    private final FCMTokenService fcmTokenService;
+    private final FCMService fcmService;
+
+    // FCM 토큰 저장 API
+    @Operation(summary = "FCM 토큰 저장", description = "로그인된 사용자의 FCM 토큰을 저장합니다.")
+    @PostMapping("/token/{memberEmail}") //memberEmail은 추후에 Security 부분 구현 완료되면 인증된 사용자에서 email 뽑아오는걸로 리팩토링
+    public CustomResponse<String> registerFcmToken(@RequestBody FCMReqDTO.FCMTokenDTO fcmTokenDTO,
+                                                   @PathVariable String memberEmail) {
+        fcmTokenService.saveFcmToken(memberEmail, fcmTokenDTO.fcmToken());
+        return CustomResponse.onSuccess("성공적으로 FCM 토큰이 저장되었습니다.");
+    }
+
+    // FCM 푸시 알림 전송 API
+    @Operation(summary = "테스트 FCM 푸시 알림 전송", description = "지정된 FCM 토큰으로 푸시 알림을 전송합니다.")
+    @PostMapping("/send")
+    public CustomResponse<String> sendNotification(@RequestBody FCMReqDTO.FCMSendDTO fcmSendDTO) {
+        fcmService.sendFcmNotification(fcmSendDTO);
+        return CustomResponse.onSuccess("성공적으로 알림이 전송되었습니다.");
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/converter/FCMConverter.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/converter/FCMConverter.java
@@ -1,0 +1,23 @@
+package com.project.smunionbe.domain.notification.fcm.converter;
+
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.project.smunionbe.domain.notification.fcm.dto.request.FCMReqDTO;
+
+public class FCMConverter {
+
+    // FcmSendDto를 기반으로 Firebase Message 객체를 생성하는 메서드
+    public static Message toFirebaseMessage(FCMReqDTO.FCMSendDTO fcmSendDTO) {
+        // 알림 정보 설정
+        Notification notification = Notification.builder()
+                .setTitle(fcmSendDTO.title())
+                .setBody(fcmSendDTO.body())
+                .build();
+
+        // 메시지 빌드 (토큰과 알림 내용 포함)
+        return Message.builder()
+                .setToken(fcmSendDTO.fcmToken())
+                .setNotification(notification)
+                .build();
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/dto/request/FCMReqDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/dto/request/FCMReqDTO.java
@@ -1,0 +1,19 @@
+package com.project.smunionbe.domain.notification.fcm.dto.request;
+
+import lombok.Builder;
+
+public class FCMReqDTO {
+
+    @Builder
+    public record FCMSendDTO(
+            String fcmToken,
+            String title,
+            String body
+    ) {
+    }
+
+    public record FCMTokenDTO(
+            String fcmToken
+    ) {
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/exception/FCMErrorCode.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/exception/FCMErrorCode.java
@@ -1,0 +1,19 @@
+package com.project.smunionbe.domain.notification.fcm.exception;
+
+import com.project.smunionbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FCMErrorCode implements BaseErrorCode {
+
+    FCMTOKEN_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "Notification400_0", "해당 유저의 FCM 토큰이 이미 존재합니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "Notification404_0", "해당 알림을 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/exception/FCMException.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/exception/FCMException.java
@@ -1,0 +1,12 @@
+package com.project.smunionbe.domain.notification.fcm.exception;
+
+import com.project.smunionbe.global.apiPayload.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class FCMException extends CustomException {
+
+    public FCMException(FCMErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/service/command/FCMService.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/service/command/FCMService.java
@@ -1,0 +1,29 @@
+package com.project.smunionbe.domain.notification.fcm.service.command;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.project.smunionbe.domain.notification.fcm.converter.FCMConverter;
+import com.project.smunionbe.domain.notification.fcm.dto.request.FCMReqDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FCMService {
+
+    // FCM 푸시 알림 전송 메서드
+    public void sendFcmNotification(FCMReqDTO.FCMSendDTO fcmSendDTO) {
+        Message message = FCMConverter.toFirebaseMessage(fcmSendDTO);
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("푸시 알림 전송 성공: {}", response);
+        } catch (Exception e) {
+            log.error("푸시 알림 전송 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/service/command/FCMTokenService.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/service/command/FCMTokenService.java
@@ -56,4 +56,17 @@ public class FCMTokenService {
         redisUtil.save(redisKey, fcmToken, TOKEN_EXPIRATION_DAYS, TimeUnit.DAYS);
         log.info("[FcmTokenService] 사용자 {}의 FCM 토큰이 저장되었습니다.", email);
     }
+
+    // Redis에서 FCM 토큰 조회
+    public String getFcmToken(String email) {
+        String redisKey = generateRedisKey(email);
+        Object result = redisUtil.get(redisKey);
+
+        if (result instanceof String) {
+            return (String) result; // 명시적 타입 변환
+        } else {
+            log.warn("Redis에서 가져온 값이 String 타입이 아닙니다. 키: {}", redisKey);
+            return null; // 또는 빈 문자열 반환
+        }
+    }
 }

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/service/command/FCMTokenService.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/service/command/FCMTokenService.java
@@ -1,0 +1,59 @@
+package com.project.smunionbe.domain.notification.fcm.service.command;
+
+import com.project.smunionbe.domain.notification.fcm.exception.FCMErrorCode;
+import com.project.smunionbe.domain.notification.fcm.exception.FCMException;
+import com.project.smunionbe.global.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FCMTokenService {
+
+    private static final long TOKEN_EXPIRATION_DAYS = 30L;  // 토큰 만료일 상수(refreshToken 만료일과 동일하게 설정)
+    private final RedisUtil redisUtil;
+
+    // FCM 토큰 저장
+    @Transactional
+    public void saveFcmToken(String email, String fcmToken) {
+        if (hasFcmToken(email)) {
+            throw new FCMException(FCMErrorCode.FCMTOKEN_ALREADY_EXIST);
+        }
+        saveFcmTokenInRedis(email, fcmToken);
+    }
+
+    // FCM 토큰 삭제
+    public void deleteFcmToken(String email) {
+        String redisKey = generateRedisKey(email);
+        boolean deleted = redisUtil.delete(redisKey);
+
+        if (deleted) {
+            log.info("[FcmTokenService] 사용자 {}의 FCM 토큰이 삭제되었습니다.", email);
+        } else {
+            log.warn("[FcmTokenService] 사용자 {}의 FCM 토큰을 찾을 수 없습니다.", email);
+        }
+    }
+
+    // Redis 키 생성 로직
+    private String generateRedisKey(String email) {
+        return "FCM_TOKEN:" + email;
+    }
+
+    // FCM 토큰 존재 여부 확인
+    public boolean hasFcmToken(String email) {
+        String redisKey = generateRedisKey(email);
+        return redisUtil.hasKey(redisKey);
+    }
+
+    // Redis에 FCM 토큰 저장
+    private void saveFcmTokenInRedis(String email, String fcmToken) {
+        String redisKey = generateRedisKey(email);
+        redisUtil.save(redisKey, fcmToken, TOKEN_EXPIRATION_DAYS, TimeUnit.DAYS);
+        log.info("[FcmTokenService] 사용자 {}의 FCM 토큰이 저장되었습니다.", email);
+    }
+}

--- a/src/main/java/com/project/smunionbe/global/config/FirebaseConfig.java
+++ b/src/main/java/com/project/smunionbe/global/config/FirebaseConfig.java
@@ -1,0 +1,33 @@
+package com.project.smunionbe.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    // application.yml에서 Firebase 서비스 계정 파일 경로를 가져옴
+    @Value("${firebase.config.path}")
+    private String keyPath;
+
+    @Bean
+    public FirebaseApp initializeFirebase() throws IOException {
+        // ClassPathResource로 리소스 경로에서 파일을 불러옴
+        ClassPathResource resource = new ClassPathResource(keyPath);
+
+        // Firebase 옵션 설정
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
+                .build();
+
+        // FirebaseApp을 초기화하고 빈으로 등록
+        return FirebaseApp.initializeApp(options);
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number

- #9 

##  📌 개요

- FCM 토큰을 Reqeust로 받아 redis에 저장하는 API 개발
- 푸시 알림 테스트 용 API 개발
- 공지 생성 시 푸시 알림이 가도록 로직 추가

## 🔁 변경 사항
3c7e2ccd383f048ecba90676bd13cbab44c3f20a
- FCM 토큰을 Reqeust로 받아 redis에 저장하는 API 개발
- 푸시 알림 테스트 용 API 개발

c4b2af503d3f9445544ba5c2c3cf33f35271bf55
- 공지 생성 시 푸시 알림이 가도록 로직 추가

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
테스트 필요

추가적으로 yml 변경된 것과 FCM JSON 파일은 카카오톡을 통해 공유드리겠습니다.