### PR TITLE
✨feat: 출석 공지 API와 memberId 연결

### DIFF
--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/controller/AttendanceController.java
@@ -1,5 +1,6 @@
 package com.project.smunionbe.domain.notification.attendance.controller;
 
+import com.project.smunionbe.domain.member.security.CustomUserDetails;
 import com.project.smunionbe.domain.notification.attendance.dto.request.AttendanceReqDTO;
 import com.project.smunionbe.domain.notification.attendance.dto.response.AttendanceResDTO;
 import com.project.smunionbe.domain.notification.attendance.service.command.AttendanceCommandService;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,33 +28,33 @@ public class AttendanceController {
     private final AttendanceCommandService attendanceCommandService;
     private final AttendanceQueryService attendanceQueryService;
 
-    @PostMapping("/{memberId}")
+    @PostMapping("")
     @Operation(
             summary = "출석 공지 생성 API",
             description = "멤버가 속한 동아리에서 새로운 출석 공지를 생성합니다."
     )
     public ResponseEntity<CustomResponse<String>> createAttendance(
             @RequestBody @Valid AttendanceReqDTO.CreateAttendanceDTO request,
-            @PathVariable Long memberId) {
-        attendanceCommandService.createAttendance(request, memberId);
+            @AuthenticationPrincipal CustomUserDetails authMember) {
+        attendanceCommandService.createAttendance(request, authMember.getMember().getId());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CustomResponse.onSuccess(HttpStatus.CREATED, "출석 공지가 성공적으로 생성되었습니다."));
     }
 
-    @GetMapping("/status/{memberId}")
+    @GetMapping("/status")
     @Operation(
             summary = "미출석 인원 조회 API",
             description = "특정 출석 공지에서 아직 출석하지 않은 멤버를 조회합니다."
     )
     public CustomResponse<AttendanceResDTO.AttendanceAbsenteesResponse> getAbsentees(
             @RequestParam("attendanceId") Long attendanceId,
-            @PathVariable Long memberId
+            @AuthenticationPrincipal CustomUserDetails authMember
     ) {
-        AttendanceResDTO.AttendanceAbsenteesResponse response = attendanceQueryService.getAbsentees(attendanceId, memberId);
+        AttendanceResDTO.AttendanceAbsenteesResponse response = attendanceQueryService.getAbsentees(attendanceId, authMember.getMember().getId());
         return CustomResponse.onSuccess(response);
     }
 
-    @GetMapping("/{memberId}")
+    @GetMapping("")
     @Operation(
             summary = "출석 공지 목록 조회 API",
             description = "특정 동아리의 모든 출석 공지를 커서 기반 페이지네이션으로 조회합니다."
@@ -66,27 +68,27 @@ public class AttendanceController {
             @RequestParam("clubId") Long clubId,
             @RequestParam(value = "cursor", required = false) Long cursor,
             @RequestParam(value = "size", defaultValue = "10") int size,
-            @PathVariable Long memberId
+            @AuthenticationPrincipal CustomUserDetails authMember
     ) {
         AttendanceResDTO.AttendanceListResponse response =
-                attendanceQueryService.getAttendances(clubId, cursor, size, memberId);
+                attendanceQueryService.getAttendances(clubId, cursor, size, authMember.getMember().getId());
         return CustomResponse.onSuccess(response);
     }
 
-    @GetMapping("/{attendanceId}/{memberId}")
+    @GetMapping("/{attendanceId}")
     @Operation(
             summary = "출석 공지 상세 조회 API",
             description = "특정 출석 공지의 상세 정보를 조회합니다."
     )
     public CustomResponse<AttendanceResDTO.AttendanceDetailResponse> getAttendanceDetail(
             @PathVariable("attendanceId") Long attendanceId,
-            @PathVariable Long memberId
+            @AuthenticationPrincipal CustomUserDetails authMember
     ) {
-        AttendanceResDTO.AttendanceDetailResponse response = attendanceQueryService.getAttendanceDetail(attendanceId, memberId);
+        AttendanceResDTO.AttendanceDetailResponse response = attendanceQueryService.getAttendanceDetail(attendanceId, authMember.getMember().getId());
         return CustomResponse.onSuccess(response);
     }
 
-    @PatchMapping("/{attendanceId}/{memberId}")
+    @PatchMapping("/{attendanceId}")
     @Operation(
             summary = "출석 공지 수정 API",
             description = "기존 출석 공지의 내용을 수정합니다."
@@ -94,35 +96,35 @@ public class AttendanceController {
     public CustomResponse<String> updateAttendance(
             @PathVariable("attendanceId") Long attendanceId,
             @RequestBody @Valid AttendanceReqDTO.UpdateAttendanceRequest request,
-            @PathVariable Long memberId
+            @AuthenticationPrincipal CustomUserDetails authMember
     ) {
-        attendanceCommandService.updateAttendance(attendanceId, request, memberId);
+        attendanceCommandService.updateAttendance(attendanceId, request, authMember.getMember().getId());
         return CustomResponse.onSuccess("출석 공지 수정 성공");
     }
 
-    @DeleteMapping("/{attendanceId}/{memberId}")
+    @DeleteMapping("/{attendanceId}")
     @Operation(
             summary = "출석 공지 삭제 API",
             description = "특정 출석 공지를 삭제합니다."
     )
     public CustomResponse<String> deleteAttendance(
             @PathVariable("attendanceId") Long attendanceId,
-            @PathVariable Long memberId
+            @AuthenticationPrincipal CustomUserDetails authMember
     ) {
-        attendanceCommandService.deleteAttendance(attendanceId, memberId);
+        attendanceCommandService.deleteAttendance(attendanceId, authMember.getMember().getId());
         return CustomResponse.onSuccess("출석 공지가 성공적으로 삭제되었습니다.");
     }
 
-    @PostMapping("/verify/{memberId}")
+    @PostMapping("/verify")
     @Operation(
             summary = "출석 상태 업데이트 API",
             description = "특정 출석 공지에 대해 사용자의 출석 상태를 업데이트합니다."
     )
     public CustomResponse<String> verifyAttendance(
             @RequestBody @Valid AttendanceReqDTO.VerifyAttendanceRequest request,
-            @PathVariable Long memberId
+            @AuthenticationPrincipal CustomUserDetails authMember
     ) {
-        attendanceCommandService.verifyAttendance(request, memberId);
+        attendanceCommandService.verifyAttendance(request, authMember.getMember().getId());
         return CustomResponse.onSuccess("출석이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/project/smunionbe/domain/notification/fcm/controller/FCMController.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/fcm/controller/FCMController.java
@@ -1,5 +1,6 @@
 package com.project.smunionbe.domain.notification.fcm.controller;
 
+import com.project.smunionbe.domain.member.security.CustomUserDetails;
 import com.project.smunionbe.domain.notification.fcm.dto.request.FCMReqDTO;
 import com.project.smunionbe.domain.notification.fcm.service.command.FCMService;
 import com.project.smunionbe.domain.notification.fcm.service.command.FCMTokenService;
@@ -7,6 +8,7 @@ import com.project.smunionbe.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,10 +22,10 @@ public class FCMController {
 
     // FCM 토큰 저장 API
     @Operation(summary = "FCM 토큰 저장", description = "로그인된 사용자의 FCM 토큰을 저장합니다.")
-    @PostMapping("/token/{memberEmail}") //memberEmail은 추후에 Security 부분 구현 완료되면 인증된 사용자에서 email 뽑아오는걸로 리팩토링
+    @PostMapping("/token")
     public CustomResponse<String> registerFcmToken(@RequestBody FCMReqDTO.FCMTokenDTO fcmTokenDTO,
-                                                   @PathVariable String memberEmail) {
-        fcmTokenService.saveFcmToken(memberEmail, fcmTokenDTO.fcmToken());
+                                                   @AuthenticationPrincipal CustomUserDetails authMember) {
+        fcmTokenService.saveFcmToken(authMember.getUsername(), fcmTokenDTO.fcmToken());
         return CustomResponse.onSuccess("성공적으로 FCM 토큰이 저장되었습니다.");
     }
 

--- a/src/main/java/com/project/smunionbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/smunionbe/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.project.smunionbe.global.config;
 
 import com.project.smunionbe.domain.member.repository.RefreshTokenRepository;
 import com.project.smunionbe.domain.member.security.CustomUserDetailsService;
+import com.project.smunionbe.global.config.jwt.TokenAuthenticationFilter;
+import com.project.smunionbe.global.config.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +18,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -25,6 +28,8 @@ public class SecurityConfig {
     private final CustomUserDetailsService userDetailsService;
 
     private final AuthenticationConfiguration authenticationConfiguration;
+
+    private final TokenProvider tokenProvider;
 
     //인증이 필요하지 않은 url
     private final String[] allowedUrls = {
@@ -81,6 +86,10 @@ public class SecurityConfig {
                         //위에서 정의했던 allowedUrls 들은 인증이 필요하지 않음 -> permitAll
                         .requestMatchers(allowedUrls).permitAll()
                         .anyRequest().authenticated()); // 그 외의 url 들은 인증이 필요함
+
+        http
+                .addFilterBefore(new TokenAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
     }

--- a/src/main/java/com/project/smunionbe/global/config/jwt/TokenProvider.java
+++ b/src/main/java/com/project/smunionbe/global/config/jwt/TokenProvider.java
@@ -1,6 +1,8 @@
 package com.project.smunionbe.global.config.jwt;
 
 import com.project.smunionbe.domain.member.entity.Member;
+import com.project.smunionbe.domain.member.repository.MemberRepository;
+import com.project.smunionbe.domain.member.security.CustomUserDetails;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
@@ -23,6 +25,7 @@ import java.util.Set;
 @Service
 public class TokenProvider {
     private final JwtProperties jwtProperties;
+    private final MemberRepository memberRepository;
 
     public String generateToken(Member member, Duration expiredAt) {
         Date now = new Date();
@@ -62,10 +65,13 @@ public class TokenProvider {
     //토큰 기반으로 인증 정보를 가져오는 메서드
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
-        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")); //추후 권한 변경
+        Long memberId = claims.get("id", Long.class);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("유효하지 않은 사용자 ID"));
 
-        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), token, authorities);
-        //비밀번호는 JWT 인증에서 필요하지 않으므로 빈 값 ""
+        // CustomUserDetails로 인증 정보 생성
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+        return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
     }
 
 


### PR DESCRIPTION
# ☝️Issue Number

- #16 

##  📌 개요

- 출석 공지 API와 memberId 연결하였습니다.
- DB에 더미데이터 넣어서 테스트 완료하였습니다.

## 🔁 변경 사항
dc0ab2fd46747bb157c35e810696ed1e91f31968
- 출석 공지 API와 memberId 연결
- Security 오류 해결

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
추후에 공지생성은 특정 권한만 가능하도록 권한검증 코드 추가하겠습니다.

추가로 Controller에서 CustomUserDetails를 못잡는 현상 해결하였습니다.
- 로그인필터 앞에 JWT 검증필터 추가
- TokenProvider에서 CustomUserDetails 객체를 생성

추가로 사용자가 Club을 생성했을 때 memberClub 테이블에 컬럼 추가하는 코드 필요합니다.