### PR TITLE
Feat: 가입되어 있는 모든 동아리 조회 API, 동아리 하나 선택 API, 선택되어있는 동아리 조회 API, 게시글 쓰기 API 구현 완료

### DIFF
--- a/src/main/java/com/project/smunionbe/domain/community/controller/ArticleController.java
+++ b/src/main/java/com/project/smunionbe/domain/community/controller/ArticleController.java
@@ -5,9 +5,12 @@ import com.project.smunionbe.domain.community.dto.response.ArticleResponseDTO;
 import com.project.smunionbe.domain.community.entity.Article;
 import com.project.smunionbe.domain.community.service.ArticleService;
 import com.project.smunionbe.domain.member.dto.request.MemberRequestDTO;
+import com.project.smunionbe.domain.member.service.ClubSelectionService;
 import com.project.smunionbe.global.apiPayload.CustomResponse;
+import com.project.smunionbe.global.config.jwt.TokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,18 +26,21 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "커뮤니티 게시글 API", description = "-")
 public class ArticleController {
     private final ArticleService articleService;
+    private final TokenProvider tokenProvider;
+    private final ClubSelectionService clubSelectionService;
 
     @PostMapping()
     @Operation(
             summary = "게시글 작성 API",
             description = "게시글 작성 API"
     ) //여기에 이어서 작성
-    public ResponseEntity<CustomResponse<ArticleResponseDTO.ArticleResponse>> createArticle(@RequestBody ArticleRequestDTO.CreateArticleRequest dto, HttpSession session) {
+    public ResponseEntity<CustomResponse<ArticleResponseDTO.ArticleResponse>> createArticle(@RequestBody ArticleRequestDTO.CreateArticleRequest dto, HttpServletRequest request, HttpSession session) {
         //세션에서 memberClubId 가져오기
-        //Long selectedMemberClubId = profileSelectionService.getSelectedProfile(session);
+        Long memberId = tokenProvider.getUserId(tokenProvider.resolveToken(request));
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, memberId);
 
         // 게시글 생성
-        ArticleResponseDTO.ArticleResponse response = articleService.createArticle(dto, dto.memberClubId());
+        ArticleResponseDTO.ArticleResponse response = articleService.createArticle(dto, selectedMemberClubId);
 
 
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/project/smunionbe/domain/community/controller/ArticleController.java
+++ b/src/main/java/com/project/smunionbe/domain/community/controller/ArticleController.java
@@ -1,0 +1,44 @@
+package com.project.smunionbe.domain.community.controller;
+
+import com.project.smunionbe.domain.community.dto.request.ArticleRequestDTO;
+import com.project.smunionbe.domain.community.dto.response.ArticleResponseDTO;
+import com.project.smunionbe.domain.community.entity.Article;
+import com.project.smunionbe.domain.community.service.ArticleService;
+import com.project.smunionbe.domain.member.dto.request.MemberRequestDTO;
+import com.project.smunionbe.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/community")
+@Tag(name = "커뮤니티 게시글 API", description = "-")
+public class ArticleController {
+    private final ArticleService articleService;
+
+    @PostMapping()
+    @Operation(
+            summary = "게시글 작성 API",
+            description = "게시글 작성 API"
+    ) //여기에 이어서 작성
+    public ResponseEntity<CustomResponse<ArticleResponseDTO.ArticleResponse>> createArticle(@RequestBody ArticleRequestDTO.CreateArticleRequest dto, HttpSession session) {
+        //세션에서 memberClubId 가져오기
+        //Long selectedMemberClubId = profileSelectionService.getSelectedProfile(session);
+
+        // 게시글 생성
+        ArticleResponseDTO.ArticleResponse response = articleService.createArticle(dto, dto.memberClubId());
+
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CustomResponse.onSuccess(HttpStatus.CREATED, response));
+    }
+
+}

--- a/src/main/java/com/project/smunionbe/domain/community/converter/ArticleConverter.java
+++ b/src/main/java/com/project/smunionbe/domain/community/converter/ArticleConverter.java
@@ -1,0 +1,27 @@
+package com.project.smunionbe.domain.community.converter;
+
+import com.project.smunionbe.domain.community.dto.request.ArticleRequestDTO;
+import com.project.smunionbe.domain.community.dto.response.ArticleResponseDTO;
+import com.project.smunionbe.domain.community.entity.Article;
+import com.project.smunionbe.domain.member.dto.request.MemberRequestDTO;
+import com.project.smunionbe.domain.member.entity.Member;
+import com.project.smunionbe.domain.member.entity.MemberClub;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArticleConverter {
+    public Article toArticle(ArticleRequestDTO.CreateArticleRequest dto, MemberClub memberClub) {
+        return Article.builder()
+                .memberClub(memberClub)
+                .department("department")
+                .memberName("memberName")
+                .title(dto.title())
+                .content(dto.content())
+                .LikeNum(0)
+                .build();
+    }
+
+    public ArticleResponseDTO.ArticleResponse toArticleResponseDto(Article article) {
+        return new ArticleResponseDTO.ArticleResponse(article.getId(), article.getTitle(), article.getContent(), article.getLikeNum());
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/community/converter/ArticleConverter.java
+++ b/src/main/java/com/project/smunionbe/domain/community/converter/ArticleConverter.java
@@ -1,5 +1,7 @@
 package com.project.smunionbe.domain.community.converter;
 
+import com.project.smunionbe.domain.club.entity.Club;
+import com.project.smunionbe.domain.club.entity.Department;
 import com.project.smunionbe.domain.community.dto.request.ArticleRequestDTO;
 import com.project.smunionbe.domain.community.dto.response.ArticleResponseDTO;
 import com.project.smunionbe.domain.community.entity.Article;
@@ -10,11 +12,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ArticleConverter {
-    public Article toArticle(ArticleRequestDTO.CreateArticleRequest dto, MemberClub memberClub) {
+    public Article toArticle(ArticleRequestDTO.CreateArticleRequest dto, MemberClub memberClub, Club club, Department department) {
         return Article.builder()
                 .memberClub(memberClub)
-                .department("department")
-                .memberName("memberName")
+                .department(department.getName())
+                .memberName(club.getName())
                 .title(dto.title())
                 .content(dto.content())
                 .LikeNum(0)

--- a/src/main/java/com/project/smunionbe/domain/community/dto/request/ArticleRequestDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/community/dto/request/ArticleRequestDTO.java
@@ -1,0 +1,12 @@
+package com.project.smunionbe.domain.community.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class ArticleRequestDTO {
+
+    public record CreateArticleRequest(
+            @NotBlank Long memberClubId,
+            @NotBlank String title,      // 게시글 제목
+            @NotBlank String content   // 게시글 내용
+    ) {}
+}

--- a/src/main/java/com/project/smunionbe/domain/community/dto/request/ArticleRequestDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/community/dto/request/ArticleRequestDTO.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 public class ArticleRequestDTO {
 
     public record CreateArticleRequest(
-            @NotBlank Long memberClubId,
             @NotBlank String title,      // 게시글 제목
             @NotBlank String content   // 게시글 내용
     ) {}

--- a/src/main/java/com/project/smunionbe/domain/community/dto/response/ArticleResponseDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/community/dto/response/ArticleResponseDTO.java
@@ -1,0 +1,11 @@
+package com.project.smunionbe.domain.community.dto.response;
+
+public class ArticleResponseDTO {
+
+    public record ArticleResponse(
+            Long id,
+            String title,
+            String content,
+            Integer likeNum
+    ) {}
+}

--- a/src/main/java/com/project/smunionbe/domain/community/entity/Likes.java
+++ b/src/main/java/com/project/smunionbe/domain/community/entity/Likes.java
@@ -9,31 +9,18 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@Table(name = "article")
-public class Article {
-
+@Table(name = "likes")
+public class Likes {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne
+    @JoinColumn(name = "article_id")
+    private Article article;
+
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_club_id", nullable = false)
     private MemberClub memberClub;
-
-    @Column(name = "title", nullable = false)
-    private String title;
-
-    @Lob
-    @Column(name = "content", nullable = false)
-    private String content;
-
-    @Column(name = "department", nullable = false)
-    private String department;
-
-    @Column(name = "member_name", nullable = false)
-    private String memberName;
-
-    @Column(name = "like_num", nullable = false)
-    @Builder.Default
-    private Integer LikeNum = 0;
 }

--- a/src/main/java/com/project/smunionbe/domain/community/exception/ArticleErrorCode.java
+++ b/src/main/java/com/project/smunionbe/domain/community/exception/ArticleErrorCode.java
@@ -1,0 +1,17 @@
+package com.project.smunionbe.domain.community.exception;
+
+import com.project.smunionbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ArticleErrorCode implements BaseErrorCode {
+    // 사용자 관련 에러
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Auth404_0", "존재하지 않는 유저입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/smunionbe/domain/community/exception/ArticleException.java
+++ b/src/main/java/com/project/smunionbe/domain/community/exception/ArticleException.java
@@ -1,0 +1,9 @@
+package com.project.smunionbe.domain.community.exception;
+
+import com.project.smunionbe.global.apiPayload.exception.CustomException;
+
+public class ArticleException extends CustomException {
+    public ArticleException(ArticleErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/community/repository/ArticleRepository.java
+++ b/src/main/java/com/project/smunionbe/domain/community/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package com.project.smunionbe.domain.community.repository;
+
+import com.project.smunionbe.domain.community.entity.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/java/com/project/smunionbe/domain/community/service/ArticleService.java
+++ b/src/main/java/com/project/smunionbe/domain/community/service/ArticleService.java
@@ -1,11 +1,17 @@
 package com.project.smunionbe.domain.community.service;
 
+import com.project.smunionbe.domain.club.entity.Club;
+import com.project.smunionbe.domain.club.entity.Department;
+import com.project.smunionbe.domain.club.repository.ClubRepository;
+import com.project.smunionbe.domain.club.repository.DepartmentRepository;
 import com.project.smunionbe.domain.community.converter.ArticleConverter;
 import com.project.smunionbe.domain.community.dto.request.ArticleRequestDTO;
 import com.project.smunionbe.domain.community.dto.response.ArticleResponseDTO;
 import com.project.smunionbe.domain.community.entity.Article;
 import com.project.smunionbe.domain.community.repository.ArticleRepository;
 import com.project.smunionbe.domain.member.entity.MemberClub;
+import com.project.smunionbe.domain.member.exception.MemberClubErrorCode;
+import com.project.smunionbe.domain.member.exception.MemberClubException;
 import com.project.smunionbe.domain.member.repository.MemberClubRepository;
 import com.project.smunionbe.domain.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -17,6 +23,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class ArticleService {
     private final ArticleRepository articleRepository;
+    private final ClubRepository clubRepository;
+    private final DepartmentRepository departmentRepository;
     private final MemberClubRepository memberClubRepository;
     private final ArticleConverter articleConverter;
 
@@ -26,10 +34,20 @@ public class ArticleService {
     public ArticleResponseDTO.ArticleResponse createArticle(ArticleRequestDTO.CreateArticleRequest dto, Long selectedMemberClubId) {
         // MemberClub 조회
         MemberClub memberClub = memberClubRepository.findById(selectedMemberClubId)
-                .orElseThrow(() -> new EntityNotFoundException("MemberClub not found"));
+                .orElseThrow(() -> new MemberClubException(MemberClubErrorCode.MEMBER_CLUB_NOT_FOUND));
+
+        Long clubId = memberClub.getClub().getId();
+        Long departmentId = memberClub.getDepartment().getId();
+
+        //동아리 조회
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new MemberClubException(MemberClubErrorCode.CLUB_NOT_FOUND));
+        //부서 조회
+        Department department = departmentRepository.findById(departmentId)
+                .orElseThrow(() -> new MemberClubException(MemberClubErrorCode.DEPARTMENT_NOT_FOUND));
 
         // 게시글 엔티티 생성
-        Article article = articleConverter.toArticle(dto, memberClub);
+        Article article = articleConverter.toArticle(dto, memberClub, club, department);
 
         // 저장
         articleRepository.save(article);

--- a/src/main/java/com/project/smunionbe/domain/community/service/ArticleService.java
+++ b/src/main/java/com/project/smunionbe/domain/community/service/ArticleService.java
@@ -1,0 +1,40 @@
+package com.project.smunionbe.domain.community.service;
+
+import com.project.smunionbe.domain.community.converter.ArticleConverter;
+import com.project.smunionbe.domain.community.dto.request.ArticleRequestDTO;
+import com.project.smunionbe.domain.community.dto.response.ArticleResponseDTO;
+import com.project.smunionbe.domain.community.entity.Article;
+import com.project.smunionbe.domain.community.repository.ArticleRepository;
+import com.project.smunionbe.domain.member.entity.MemberClub;
+import com.project.smunionbe.domain.member.repository.MemberClubRepository;
+import com.project.smunionbe.domain.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleService {
+    private final ArticleRepository articleRepository;
+    private final MemberClubRepository memberClubRepository;
+    private final ArticleConverter articleConverter;
+
+
+    //게시글 생성
+    @Transactional
+    public ArticleResponseDTO.ArticleResponse createArticle(ArticleRequestDTO.CreateArticleRequest dto, Long selectedMemberClubId) {
+        // MemberClub 조회
+        MemberClub memberClub = memberClubRepository.findById(selectedMemberClubId)
+                .orElseThrow(() -> new EntityNotFoundException("MemberClub not found"));
+
+        // 게시글 엔티티 생성
+        Article article = articleConverter.toArticle(dto, memberClub);
+
+        // 저장
+        articleRepository.save(article);
+
+        // 저장 후 ID 반환
+        return articleConverter.toArticleResponseDto(article);
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/member/controller/MemberClubController.java
+++ b/src/main/java/com/project/smunionbe/domain/member/controller/MemberClubController.java
@@ -4,6 +4,7 @@ import com.project.smunionbe.domain.member.converter.MemberClubConverter;
 import com.project.smunionbe.domain.member.dto.response.MemberClubResponseDTO;
 import com.project.smunionbe.domain.member.entity.MemberClub;
 import com.project.smunionbe.domain.member.security.CustomUserDetails;
+import com.project.smunionbe.domain.member.service.ClubSelectionService;
 import com.project.smunionbe.domain.member.service.MemberClubService;
 import com.project.smunionbe.domain.member.service.MemberService;
 import com.project.smunionbe.domain.member.service.TokenService;
@@ -12,13 +13,12 @@ import com.project.smunionbe.global.config.jwt.TokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,10 +27,10 @@ import java.util.List;
 @RequestMapping("/api/v1/users")
 @Tag(name = "동아리 회원 API", description = "-")
 public class MemberClubController {
-    private final MemberService memberService;
+
     private final MemberClubService memberClubService;
-    private final MemberClubConverter memberClubConverter;
     private final TokenProvider tokenProvider;
+    private final ClubSelectionService clubSelectionService;
 
     // 해당 멤버가 가입되어있는 모든 동아리 조회
     @GetMapping("/clubs")
@@ -46,5 +46,37 @@ public class MemberClubController {
         // 성공 응답 반환
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CustomResponse.onSuccess(HttpStatus.OK, responses));
+    }
+
+    // 조회된 동아리 중 하나 선택하여 세션에 저장
+    @PostMapping("/clubs/select")
+    @Operation(
+            summary = "특정 동아리 프로필 선택 API",
+            description = "조회된 동아리 리스트 중 하나를 선택하여 세션에 저장하는 API 입니다."
+    )
+    public ResponseEntity<CustomResponse<MemberClubResponseDTO.MemberClubResponse>> selectClubProfile(@RequestParam Long memberClubId, HttpServletRequest request, HttpSession session) {
+        Long memberId = tokenProvider.getUserId(tokenProvider.resolveToken(request));
+        memberClubService.validateAndSetSelectedProfile(memberId, memberClubId, session);
+
+        MemberClubResponseDTO.MemberClubResponse response = memberClubService.findById(memberClubId);
+
+        // 성공 응답 반환
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CustomResponse.onSuccess(HttpStatus.OK, response));
+    }
+
+
+    // 선택된 프로필 조회
+    @GetMapping("/clubs/selected")
+    @Operation(
+            summary = "선택된 동아리 프로필 조회 API",
+            description = "현재 세션에 저장된 선택된 동아리 프로필 정보를 조회하는 API"
+    )
+    public ResponseEntity<CustomResponse<MemberClubResponseDTO.MemberClubResponse>> getSelectedMemberClub(HttpServletRequest request, HttpSession session) {
+        Long memberId = tokenProvider.getUserId(tokenProvider.resolveToken(request));
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, memberId);
+
+        MemberClubResponseDTO.MemberClubResponse response = memberClubService.findById(selectedMemberClubId);
+        return ResponseEntity.ok(CustomResponse.onSuccess(HttpStatus.OK, response));
     }
 }

--- a/src/main/java/com/project/smunionbe/domain/member/controller/MemberClubController.java
+++ b/src/main/java/com/project/smunionbe/domain/member/controller/MemberClubController.java
@@ -1,0 +1,50 @@
+package com.project.smunionbe.domain.member.controller;
+
+import com.project.smunionbe.domain.member.converter.MemberClubConverter;
+import com.project.smunionbe.domain.member.dto.response.MemberClubResponseDTO;
+import com.project.smunionbe.domain.member.entity.MemberClub;
+import com.project.smunionbe.domain.member.security.CustomUserDetails;
+import com.project.smunionbe.domain.member.service.MemberClubService;
+import com.project.smunionbe.domain.member.service.MemberService;
+import com.project.smunionbe.domain.member.service.TokenService;
+import com.project.smunionbe.global.apiPayload.CustomResponse;
+import com.project.smunionbe.global.config.jwt.TokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users")
+@Tag(name = "동아리 회원 API", description = "-")
+public class MemberClubController {
+    private final MemberService memberService;
+    private final MemberClubService memberClubService;
+    private final MemberClubConverter memberClubConverter;
+    private final TokenProvider tokenProvider;
+
+    // 해당 멤버가 가입되어있는 모든 동아리 조회
+    @GetMapping("/clubs")
+    @Operation(
+            summary = "해당 멤버가 가입되어있는 모든 동아리 조회 API",
+            description = "해당 멤버가 가입되어있는 모든 동아리 조회 API 입니다. accessToken과 함께 요청해주세요.(\"Bearer \"없이 토큰만 입력해주세요)"
+    )
+    public ResponseEntity<CustomResponse<List<MemberClubResponseDTO.MemberClubResponse>>> getClubs(HttpServletRequest request) {
+
+        Long memberId = tokenProvider.getUserId(tokenProvider.resolveToken(request));
+        List<MemberClubResponseDTO.MemberClubResponse> responses = memberClubService.findAllByMemberId(memberId);
+
+        // 성공 응답 반환
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CustomResponse.onSuccess(HttpStatus.OK, responses));
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.project.smunionbe.domain.member.dto.request.MemberRequestDTO;
 import com.project.smunionbe.domain.member.dto.response.AccessTokenResponseDTO;
 import com.project.smunionbe.domain.member.entity.Member;
 import com.project.smunionbe.domain.member.exception.AuthErrorCode;
+import com.project.smunionbe.domain.member.security.CustomUserDetails;
 import com.project.smunionbe.domain.member.service.MemberService;
 import com.project.smunionbe.domain.member.service.RefreshTokenService;
 import com.project.smunionbe.domain.member.service.TokenService;
@@ -18,6 +19,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.web.bind.annotation.*;
@@ -89,6 +91,7 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CustomResponse.onSuccess(HttpStatus.OK, "로그아웃에 성공하였습니다."));
     }
+
 
 
 

--- a/src/main/java/com/project/smunionbe/domain/member/converter/MemberClubConverter.java
+++ b/src/main/java/com/project/smunionbe/domain/member/converter/MemberClubConverter.java
@@ -1,0 +1,44 @@
+package com.project.smunionbe.domain.member.converter;
+
+import com.project.smunionbe.domain.club.entity.Club;
+import com.project.smunionbe.domain.club.entity.Department;
+import com.project.smunionbe.domain.club.repository.ClubRepository;
+import com.project.smunionbe.domain.club.repository.DepartmentRepository;
+import com.project.smunionbe.domain.member.dto.response.MemberClubResponseDTO;
+import com.project.smunionbe.domain.member.entity.MemberClub;
+import com.project.smunionbe.domain.member.exception.MemberClubErrorCode;
+import com.project.smunionbe.domain.member.exception.MemberClubException;
+import com.project.smunionbe.domain.member.repository.MemberClubRepository;
+import com.project.smunionbe.domain.notification.attendance.exception.AttendanceErrorCode;
+import com.project.smunionbe.domain.notification.attendance.exception.AttendanceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class MemberClubConverter {
+
+    public MemberClubResponseDTO.MemberClubResponse toResponse(MemberClub memberClub, Club club, Department department) {
+        return new MemberClubResponseDTO.MemberClubResponse(
+                memberClub.getId(),
+                department.getName(),
+                club.getName(),
+                memberClub.getNickname()
+        );
+    }
+
+    public List<MemberClubResponseDTO.MemberClubResponse> toResponseList(
+            List<MemberClub> memberClubs, Map<Long, Club> clubMap, Map<Long, Department> departmentMap) {
+
+        return memberClubs.stream()
+                .map(memberClub -> {
+                    Club club = clubMap.get(memberClub.getClub().getId());
+                    Department department = departmentMap.get(club.getId());
+                    return toResponse(memberClub, club, department);
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/member/dto/response/MemberClubResponseDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/member/dto/response/MemberClubResponseDTO.java
@@ -3,7 +3,7 @@ package com.project.smunionbe.domain.member.dto.response;
 public class MemberClubResponseDTO {
 
     public record MemberClubResponse(
-            Long clubId,
+            Long memberClubId,
             String departmentName,
             String clubName,
             String nickname

--- a/src/main/java/com/project/smunionbe/domain/member/dto/response/MemberClubResponseDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/member/dto/response/MemberClubResponseDTO.java
@@ -1,0 +1,12 @@
+package com.project.smunionbe.domain.member.dto.response;
+
+public class MemberClubResponseDTO {
+
+    public record MemberClubResponse(
+            Long clubId,
+            String departmentName,
+            String clubName,
+            String nickname
+    ) {}
+}
+

--- a/src/main/java/com/project/smunionbe/domain/member/exception/MemberClubErrorCode.java
+++ b/src/main/java/com/project/smunionbe/domain/member/exception/MemberClubErrorCode.java
@@ -1,0 +1,22 @@
+package com.project.smunionbe.domain.member.exception;
+
+import com.project.smunionbe.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberClubErrorCode implements BaseErrorCode {
+    // 동아리 관련 에러
+    MEMBER_CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "Auth404_1", "해당 사용자가 가입한 동아리가 없습니다."),
+    CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "Auth404_2", "해당 동아리가 존재하지 않습니다."),
+    DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Auth404_3", "해당 동아리 부서가 존재하지 않습니다."),
+
+    // 공통 처리
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "Member400_0", "잘못된 요청입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/smunionbe/domain/member/exception/MemberClubErrorCode.java
+++ b/src/main/java/com/project/smunionbe/domain/member/exception/MemberClubErrorCode.java
@@ -9,12 +9,14 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberClubErrorCode implements BaseErrorCode {
     // 동아리 관련 에러
-    MEMBER_CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "Auth404_1", "해당 사용자가 가입한 동아리가 없습니다."),
-    CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "Auth404_2", "해당 동아리가 존재하지 않습니다."),
-    DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Auth404_3", "해당 동아리 부서가 존재하지 않습니다."),
+    MEMBER_CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "MemberClub404_1", "해당 사용자가 가입한 동아리가 없습니다."),
+    CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "MemberClub404_2", "해당 동아리가 존재하지 않습니다."),
+    DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "MemberClub404_3", "해당 동아리 부서가 존재하지 않습니다."),
+    SELECTED_NOT_FOUND(HttpStatus.NOT_FOUND, "MemberClub404_4", "저장되어 있는 동아리가 존재하지 않습니다."),
+    INVALID_MEMBER_CLUB(HttpStatus.BAD_REQUEST, "MemberClub400_2", "사용자가 속해있는 동아리가 아닙니다."),
 
     // 공통 처리
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "Member400_0", "잘못된 요청입니다.");
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "MemberClub400_0", "잘못된 요청입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/project/smunionbe/domain/member/exception/MemberClubException.java
+++ b/src/main/java/com/project/smunionbe/domain/member/exception/MemberClubException.java
@@ -1,0 +1,9 @@
+package com.project.smunionbe.domain.member.exception;
+
+import com.project.smunionbe.global.apiPayload.exception.CustomException;
+
+public class MemberClubException extends CustomException {
+    public MemberClubException(MemberClubErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/member/repository/MemberClubRepository.java
+++ b/src/main/java/com/project/smunionbe/domain/member/repository/MemberClubRepository.java
@@ -20,5 +20,8 @@ public interface MemberClubRepository extends JpaRepository<MemberClub, Long> {
     // 전체 부서 멤버 조회
     List<MemberClub> findAllByClubId(Long clubId);
 
+    // 멤버가 가입되어 있는 동아리 전체 조회
+    List<MemberClub> findAllByMemberId(Long memberId);
+
     boolean existsByMemberIdAndClubId(Long memberId, Long clubId);
 }

--- a/src/main/java/com/project/smunionbe/domain/member/service/ClubSelectionService.java
+++ b/src/main/java/com/project/smunionbe/domain/member/service/ClubSelectionService.java
@@ -1,0 +1,57 @@
+package com.project.smunionbe.domain.member.service;
+
+import com.project.smunionbe.domain.member.exception.MemberClubErrorCode;
+import com.project.smunionbe.domain.member.exception.MemberClubException;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class ClubSelectionService {
+
+    private static final String SELECTED_PROFILE_KEY = "selectedProfile";
+
+    // 선택된 프로필 저장 (memberId와 함께 저장)
+    public void setSelectedProfile(HttpSession session, Long memberId, Long memberClubId) {
+        // 세션에서 기존 데이터를 가져옴
+        Map<Long, Long> selectedProfiles = (Map<Long, Long>) session.getAttribute(SELECTED_PROFILE_KEY);
+
+        if (selectedProfiles == null) {
+            selectedProfiles = new HashMap<>();
+        }
+
+        // 기존 memberId와 관련된 데이터 갱신
+        selectedProfiles.put(memberId, memberClubId);
+
+        // 세션에 저장
+        session.setAttribute(SELECTED_PROFILE_KEY, selectedProfiles);
+    }
+
+    // 선택된 프로필 조회
+    public Long getSelectedProfile(HttpSession session, Long memberId) {
+        Map<Long, Long> selectedProfiles = (Map<Long, Long>) session.getAttribute(SELECTED_PROFILE_KEY);
+
+        if (selectedProfiles == null || !selectedProfiles.containsKey(memberId)) {
+            throw new MemberClubException(MemberClubErrorCode.SELECTED_NOT_FOUND);
+        }
+
+        return selectedProfiles.get(memberId);
+    }
+
+    // 선택된 프로필 삭제
+    public void removeSelectedProfile(HttpSession session, Long memberId) {
+        Map<Long, Long> selectedProfiles = (Map<Long, Long>) session.getAttribute(SELECTED_PROFILE_KEY);
+
+        if (selectedProfiles != null) {
+            selectedProfiles.remove(memberId);
+            // 빈 Map이 되면 세션에서 전체 키 삭제
+            if (selectedProfiles.isEmpty()) {
+                session.removeAttribute(SELECTED_PROFILE_KEY);
+            } else {
+                session.setAttribute(SELECTED_PROFILE_KEY, selectedProfiles);
+            }
+        }
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/member/service/MemberClubService.java
+++ b/src/main/java/com/project/smunionbe/domain/member/service/MemberClubService.java
@@ -1,0 +1,69 @@
+package com.project.smunionbe.domain.member.service;
+
+import com.project.smunionbe.domain.club.entity.Club;
+import com.project.smunionbe.domain.club.entity.Department;
+import com.project.smunionbe.domain.club.repository.ClubRepository;
+import com.project.smunionbe.domain.club.repository.DepartmentRepository;
+import com.project.smunionbe.domain.member.converter.MemberClubConverter;
+import com.project.smunionbe.domain.member.dto.response.MemberClubResponseDTO;
+import com.project.smunionbe.domain.member.entity.Member;
+import com.project.smunionbe.domain.member.entity.MemberClub;
+import com.project.smunionbe.domain.member.exception.AuthErrorCode;
+import com.project.smunionbe.domain.member.exception.AuthException;
+import com.project.smunionbe.domain.member.exception.MemberClubErrorCode;
+import com.project.smunionbe.domain.member.exception.MemberClubException;
+import com.project.smunionbe.domain.member.repository.MemberClubRepository;
+import com.project.smunionbe.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class MemberClubService {
+    private final MemberClubRepository memberClubRepository;
+    private final ClubRepository clubRepository;
+    private final DepartmentRepository departmentRepository;
+    private final MemberClubConverter memberClubConverter;
+
+    @Transactional(readOnly = true)
+    public List<MemberClubResponseDTO.MemberClubResponse> findAllByMemberId(Long memberId) {
+        // MemberClub 조회
+        List<MemberClub> memberClubs = memberClubRepository.findAllByMemberId(memberId);
+        if (memberClubs.isEmpty()) {
+            throw new MemberClubException(MemberClubErrorCode.MEMBER_CLUB_NOT_FOUND);
+        }
+
+        // Club 조회 및 매핑
+        List<Long> clubIds = memberClubs.stream()
+                .map(memberClub -> memberClub.getClub().getId())
+                .distinct()
+                .toList();
+
+        Map<Long, Club> clubMap = clubRepository.findAllById(clubIds).stream()
+                .collect(Collectors.toMap(Club::getId, club -> club));
+
+        for (Long clubId : clubIds) {
+            if (!clubMap.containsKey(clubId)) {
+                throw new MemberClubException(MemberClubErrorCode.CLUB_NOT_FOUND);
+            }
+        }
+
+        // Department 조회 및 매핑
+        Map<Long, Department> departmentMap = clubMap.values().stream()
+                .map(Club::getId)
+                .distinct()
+                .collect(Collectors.toMap(
+                        id -> id,
+                        id -> departmentRepository.findById(id)
+                                .orElseThrow(() -> new MemberClubException(MemberClubErrorCode.DEPARTMENT_NOT_FOUND))
+                ));
+
+        // 변환
+        return memberClubConverter.toResponseList(memberClubs, clubMap, departmentMap);
+    }
+}

--- a/src/main/java/com/project/smunionbe/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/smunionbe/domain/member/service/MemberService.java
@@ -11,6 +11,7 @@ import com.project.smunionbe.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -19,6 +20,7 @@ public class MemberService {
     private final MemberConverter memberConverter;
     private final BCryptPasswordEncoder passwordEncoder;
 
+    @Transactional
     public Long save(MemberRequestDTO.CreateMemberDTO dto) {
         // 1. 입력값 검증
         // 이메일 검사
@@ -64,6 +66,7 @@ public class MemberService {
         }
     }
 
+    @Transactional
     public Member findById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MEMBER_NOT_FOUND));
@@ -71,6 +74,7 @@ public class MemberService {
 
 
     // 회원 인증 메서드
+    @Transactional
     public Member authenticate(String email, String password) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.MEMBER_NOT_FOUND));


### PR DESCRIPTION
# ☝️Issue Number

- # 14

##  📌 개요
- **memberId를 저장하는 세션을 구현하기 위한**
- 1. 가입되어 있는 모든 동아리 조회 API
- 2. 동아리 하나 선택 API
- 3. 선택되어있는 동아리 조회 API
- 4. 위에서 구현한 memberId를 적용한 게시글 쓰기 API 구현 완료

## 🔁 변경 사항


## 📸 스크린샷
### 1. 가입되어 있는 모든 동아리 조회 API
![image](https://github.com/user-attachments/assets/394bc485-5bd7-4f15-b96f-bdeeb75162fe)
![image](https://github.com/user-attachments/assets/fcd41d11-a381-4f3f-9841-9638ddc88505)

### 2. 동아리 하나 선택 API
![image](https://github.com/user-attachments/assets/3a1a3d38-266b-4fb7-943d-b9a8e99b2dd8)
![image](https://github.com/user-attachments/assets/f5de8dc2-74d4-4c68-a895-f817a3694674)

### 3. 선택되어있는 동아리 조회 API
![image](https://github.com/user-attachments/assets/af77b33c-eb54-44de-b667-3cb19f7167b6)
![image](https://github.com/user-attachments/assets/c10cef6a-fa5e-455e-91d7-50409c3324ab)

### 4. 위에서 구현한 memberId를 적용한 게시글 쓰기 API 구현 (2번을 한번 수행해야 세션에 memberClubId가 저장이 되면서 API가 실행이 됩니다.)
![image](https://github.com/user-attachments/assets/85bab6e3-af67-4b5d-a9aa-d7a71f76bee2)
![image](https://github.com/user-attachments/assets/4bdbfda1-c847-4057-af24-512f49e70807)
![image](https://github.com/user-attachments/assets/3f3d6d29-2611-4415-b1dd-2d5aa6438631)

 

## 👀 기타 더 이야기해볼 점
` Long memberId = tokenProvider.getUserId(tokenProvider.resolveToken(request)); `
` Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, memberId); `

위 코드처럼 먼저 memberId를 조회하고, getSelectedProfile 메서드를 이용해서 세션에 저장되어있는 멤버의 memberClubId를 갖고와서 API에 사용하는 방식입니다.

그런데 세션이라서 30분이 지나면 만료되기 때문에 이걸 어떻게 처리할지(redis 고려중),
선택하지 않았다면 기본값을 어떻게 설정해줄지 
이러한 것들을 추후에 작업할 예정입니다.


------------------------

+ 언니 노트북 빌려서 작업 노트북 변경했는데 깃허브 아이디 바꾸는걸 깜빡해서 두 명이 커밋한걸로 뜹니다 ㅠㅠㅠ 중간에 바꿨습니당..