### PR TITLE
♻️refactor: memberClubId와 출석 공지 API 연결, 미출석 인원조회 API 코드 리팩토링

### DIFF
--- a/src/main/java/com/project/smunionbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/smunionbe/domain/member/repository/MemberRepository.java
@@ -12,11 +12,19 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT mc.member FROM MemberClub mc " +
             "WHERE mc.club.id = :clubId " +
+            "AND (:isAll = true OR mc.department.name IN (" +
+            "    SELECT DISTINCT tn.target FROM AttendanceNotice tn WHERE tn.id = :attendanceId" +
+            ")) " +
             "AND mc.id NOT IN (" +
             "    SELECT a.memberClub.id FROM AttendanceStatus a " +
             "    WHERE a.attendanceNotice.id = :attendanceId AND a.isPresent = true" +
             ")")
-    List<Member> findAbsenteesByAttendanceId(@Param("attendanceId") Long attendanceId, @Param("clubId") Long clubId);
+    List<Member> findAbsenteesByAttendanceId(
+            @Param("attendanceId") Long attendanceId,
+            @Param("clubId") Long clubId,
+            @Param("isAll") boolean isAll
+    );
+
 
     Optional<Member> findByEmail(String email); //이메일로 사용자의 정보를 가져옴
 

--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/controller/AttendanceController.java
@@ -1,6 +1,7 @@
 package com.project.smunionbe.domain.notification.attendance.controller;
 
 import com.project.smunionbe.domain.member.security.CustomUserDetails;
+import com.project.smunionbe.domain.member.service.ClubSelectionService;
 import com.project.smunionbe.domain.notification.attendance.dto.request.AttendanceReqDTO;
 import com.project.smunionbe.domain.notification.attendance.dto.response.AttendanceResDTO;
 import com.project.smunionbe.domain.notification.attendance.service.command.AttendanceCommandService;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +21,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notices/attendance")
 @Tag(name = "출석 공지 API", description = "출석 공지 관련 CRUD 및 기능 API")
@@ -27,104 +28,99 @@ public class AttendanceController {
 
     private final AttendanceCommandService attendanceCommandService;
     private final AttendanceQueryService attendanceQueryService;
+    private final ClubSelectionService clubSelectionService;
 
     @PostMapping("")
-    @Operation(
-            summary = "출석 공지 생성 API",
-            description = "멤버가 속한 동아리에서 새로운 출석 공지를 생성합니다."
-    )
+    @Operation(summary = "출석 공지 생성 API", description = "멤버가 속한 동아리에서 새로운 출석 공지를 생성합니다.")
     public ResponseEntity<CustomResponse<String>> createAttendance(
             @RequestBody @Valid AttendanceReqDTO.CreateAttendanceDTO request,
-            @AuthenticationPrincipal CustomUserDetails authMember) {
-        attendanceCommandService.createAttendance(request, authMember.getMember().getId());
+            @AuthenticationPrincipal CustomUserDetails authMember,
+            HttpSession session) {
+
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, authMember.getMember().getId());
+        attendanceCommandService.createAttendance(request, selectedMemberClubId);
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CustomResponse.onSuccess(HttpStatus.CREATED, "출석 공지가 성공적으로 생성되었습니다."));
     }
 
     @GetMapping("/status")
-    @Operation(
-            summary = "미출석 인원 조회 API",
-            description = "특정 출석 공지에서 아직 출석하지 않은 멤버를 조회합니다."
-    )
+    @Operation(summary = "미출석 인원 조회 API", description = "특정 출석 공지에서 아직 출석하지 않은 멤버를 조회합니다.")
     public CustomResponse<AttendanceResDTO.AttendanceAbsenteesResponse> getAbsentees(
             @RequestParam("attendanceId") Long attendanceId,
-            @AuthenticationPrincipal CustomUserDetails authMember
-    ) {
-        AttendanceResDTO.AttendanceAbsenteesResponse response = attendanceQueryService.getAbsentees(attendanceId, authMember.getMember().getId());
+            @AuthenticationPrincipal CustomUserDetails authMember,
+            HttpSession session) {
+
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, authMember.getMember().getId());
+        AttendanceResDTO.AttendanceAbsenteesResponse response = attendanceQueryService.getAbsentees(attendanceId, selectedMemberClubId);
+
         return CustomResponse.onSuccess(response);
     }
 
     @GetMapping("")
-    @Operation(
-            summary = "출석 공지 목록 조회 API",
-            description = "특정 동아리의 모든 출석 공지를 커서 기반 페이지네이션으로 조회합니다."
-    )
-    @Parameters({
-            @Parameter(name = "clubId", description = "조회 할 동아리의 id"),
-            @Parameter(name = "cursor", description = "커서 값, 처음이면 null"),
-            @Parameter(name = "size", description = "한번에 가져올 데이터의 수")
-    })
+    @Operation(summary = "출석 공지 목록 조회 API", description = "특정 동아리의 모든 출석 공지를 커서 기반 페이지네이션으로 조회합니다.")
     public CustomResponse<AttendanceResDTO.AttendanceListResponse> getAttendances(
-            @RequestParam("clubId") Long clubId,
             @RequestParam(value = "cursor", required = false) Long cursor,
             @RequestParam(value = "size", defaultValue = "10") int size,
-            @AuthenticationPrincipal CustomUserDetails authMember
-    ) {
-        AttendanceResDTO.AttendanceListResponse response =
-                attendanceQueryService.getAttendances(clubId, cursor, size, authMember.getMember().getId());
+            @AuthenticationPrincipal CustomUserDetails authMember,
+            HttpSession session) {
+
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, authMember.getMember().getId());
+        AttendanceResDTO.AttendanceListResponse response = attendanceQueryService.getAttendances(cursor, size, selectedMemberClubId);
+
         return CustomResponse.onSuccess(response);
     }
 
     @GetMapping("/{attendanceId}")
-    @Operation(
-            summary = "출석 공지 상세 조회 API",
-            description = "특정 출석 공지의 상세 정보를 조회합니다."
-    )
+    @Operation(summary = "출석 공지 상세 조회 API", description = "특정 출석 공지의 상세 정보를 조회합니다.")
     public CustomResponse<AttendanceResDTO.AttendanceDetailResponse> getAttendanceDetail(
             @PathVariable("attendanceId") Long attendanceId,
-            @AuthenticationPrincipal CustomUserDetails authMember
-    ) {
-        AttendanceResDTO.AttendanceDetailResponse response = attendanceQueryService.getAttendanceDetail(attendanceId, authMember.getMember().getId());
+            @AuthenticationPrincipal CustomUserDetails authMember,
+            HttpSession session) {
+
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, authMember.getMember().getId());
+        AttendanceResDTO.AttendanceDetailResponse response = attendanceQueryService.getAttendanceDetail(attendanceId, selectedMemberClubId);
+
         return CustomResponse.onSuccess(response);
     }
 
     @PatchMapping("/{attendanceId}")
-    @Operation(
-            summary = "출석 공지 수정 API",
-            description = "기존 출석 공지의 내용을 수정합니다."
-    )
+    @Operation(summary = "출석 공지 수정 API", description = "기존 출석 공지의 내용을 수정합니다.")
     public CustomResponse<String> updateAttendance(
             @PathVariable("attendanceId") Long attendanceId,
             @RequestBody @Valid AttendanceReqDTO.UpdateAttendanceRequest request,
-            @AuthenticationPrincipal CustomUserDetails authMember
-    ) {
-        attendanceCommandService.updateAttendance(attendanceId, request, authMember.getMember().getId());
+            @AuthenticationPrincipal CustomUserDetails authMember,
+            HttpSession session) {
+
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, authMember.getMember().getId());
+        attendanceCommandService.updateAttendance(attendanceId, request, selectedMemberClubId);
+
         return CustomResponse.onSuccess("출석 공지 수정 성공");
     }
 
     @DeleteMapping("/{attendanceId}")
-    @Operation(
-            summary = "출석 공지 삭제 API",
-            description = "특정 출석 공지를 삭제합니다."
-    )
+    @Operation(summary = "출석 공지 삭제 API", description = "특정 출석 공지를 삭제합니다.")
     public CustomResponse<String> deleteAttendance(
             @PathVariable("attendanceId") Long attendanceId,
-            @AuthenticationPrincipal CustomUserDetails authMember
-    ) {
-        attendanceCommandService.deleteAttendance(attendanceId, authMember.getMember().getId());
+            @AuthenticationPrincipal CustomUserDetails authMember,
+            HttpSession session) {
+
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, authMember.getMember().getId());
+        attendanceCommandService.deleteAttendance(attendanceId, selectedMemberClubId);
+
         return CustomResponse.onSuccess("출석 공지가 성공적으로 삭제되었습니다.");
     }
 
     @PostMapping("/verify")
-    @Operation(
-            summary = "출석 상태 업데이트 API",
-            description = "특정 출석 공지에 대해 사용자의 출석 상태를 업데이트합니다."
-    )
+    @Operation(summary = "출석 상태 업데이트 API", description = "특정 출석 공지에 대해 사용자의 출석 상태를 업데이트합니다.")
     public CustomResponse<String> verifyAttendance(
             @RequestBody @Valid AttendanceReqDTO.VerifyAttendanceRequest request,
-            @AuthenticationPrincipal CustomUserDetails authMember
-    ) {
-        attendanceCommandService.verifyAttendance(request, authMember.getMember().getId());
+            @AuthenticationPrincipal CustomUserDetails authMember,
+            HttpSession session) {
+
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, authMember.getMember().getId());
+        attendanceCommandService.verifyAttendance(request, selectedMemberClubId);
+
         return CustomResponse.onSuccess("출석이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/dto/request/AttendanceReqDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/dto/request/AttendanceReqDTO.java
@@ -6,7 +6,6 @@ import java.util.List;
 public class AttendanceReqDTO {
 
     public record CreateAttendanceDTO(
-            Long clubId,
             String title,
             String content,
             List<String> targetDepartments, // 특정 부서들
@@ -23,8 +22,7 @@ public class AttendanceReqDTO {
     }
 
     public record VerifyAttendanceRequest(
-            Long attendanceId,
-            Long clubId
+            Long attendanceId
     ){
     }
 }


### PR DESCRIPTION
# ☝️Issue Number

- #21 

##  📌 개요

- memberClubId와 출석 공지 API 연결
- 미출석 인원 조회에서 부서별 필터링이 잘 안되는 오류가 있어서 코드 수정하였습니다.

## 🔁 변경 사항
0b2c997ccc4b9da3d82c0d32b598f7bb34299aa3
- memberClubId와 출석 공지 API 연결

933f6a65b100e732b347e75359115b42c5a256eb
- 미출석 인원조회 API 코드 리팩토링

## 📸 스크린샷
테스트 모두 완료했습니다!

## 👀 기타 더 이야기해볼 점