### PR TITLE
✨ feat: 회원 추가 기능 구현 #37

### DIFF
--- a/src/main/java/com/project/smunionbe/domain/member/controller/MemberClubController.java
+++ b/src/main/java/com/project/smunionbe/domain/member/controller/MemberClubController.java
@@ -1,6 +1,7 @@
 package com.project.smunionbe.domain.member.controller;
 
 import com.project.smunionbe.domain.member.converter.MemberClubConverter;
+import com.project.smunionbe.domain.member.dto.request.MemberClubRequestDTO;
 import com.project.smunionbe.domain.member.dto.response.MemberClubResponseDTO;
 import com.project.smunionbe.domain.member.entity.MemberClub;
 import com.project.smunionbe.domain.member.security.CustomUserDetails;
@@ -79,4 +80,21 @@ public class MemberClubController {
         MemberClubResponseDTO.MemberClubResponse response = memberClubService.findById(selectedMemberClubId);
         return ResponseEntity.ok(CustomResponse.onSuccess(HttpStatus.OK, response));
     }
+
+    @PatchMapping("/clubs/nickname/{memberClubId}")
+    @Operation(
+            summary = "동아리 닉네임 변경 API",
+            description = "가입되어 있는 동아리의 닉네임을 변경하는 API입니다."
+    )
+    public ResponseEntity<CustomResponse<MemberClubResponseDTO.MemberClubResponse>> getSelectedMemberClub(@RequestBody MemberClubRequestDTO.ChangeNicknameDTO dto, @AuthenticationPrincipal CustomUserDetails auth, @PathVariable Long memberClubId) {
+        //멤버 id 가져오기
+        Long memberId = auth.getMember().getId();
+
+        //닉네임 변경
+        MemberClubResponseDTO.MemberClubResponse response = memberClubService.changeNickname(dto, memberId, memberClubId);
+
+        return ResponseEntity.ok(CustomResponse.onSuccess(HttpStatus.OK, response));
+    }
+
+
 }

--- a/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -145,8 +146,25 @@ public class MemberController {
     }
 
 
+    @PatchMapping("/password")
+    @Operation(
+            summary = "비밀번호 변경 API",
+            description = "현재 비밀번호를 검증 후 새 비밀번호로 변경하는 API입니다."
+    )
+    public ResponseEntity<CustomResponse<String>> changePassword(@AuthenticationPrincipal CustomUserDetails auth, HttpServletRequest request,@RequestBody @Valid MemberRequestDTO.ChangePasswordDTO dto) {
+        Long memberId = auth.getMember().getId();
 
+        memberService.changePassword(memberId, dto);
 
+        // 로그아웃 처리
+        String accessToken = tokenProvider.resolveToken(request);
+        if (accessToken != null) {
+            tokenService.logout(accessToken);
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CustomResponse.onSuccess(HttpStatus.OK, "비밀번호가 성공적으로 변경되었습니다."));
+    }
 
 
 }

--- a/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.project.smunionbe.domain.member.controller;
 import com.project.smunionbe.domain.member.dto.request.AccessTokenRequestDTO;
 import com.project.smunionbe.domain.member.dto.request.MemberRequestDTO;
 import com.project.smunionbe.domain.member.dto.response.AccessTokenResponseDTO;
+import com.project.smunionbe.domain.member.dto.response.MemberResponseDTO;
 import com.project.smunionbe.domain.member.entity.Member;
 import com.project.smunionbe.domain.member.exception.AuthErrorCode;
 import com.project.smunionbe.domain.member.security.CustomUserDetails;
@@ -112,6 +113,24 @@ public class MemberController {
                 .body(CustomResponse.onSuccess(HttpStatus.OK, returnTokenDTO));
 
     }
+
+
+    @GetMapping()
+    @Operation(
+            summary = "프로필 조회 API",
+            description = "회원의 프로필을 조회하는 API 입니다."
+    )
+    public ResponseEntity<CustomResponse<MemberResponseDTO.MemberProfileResponse>> getProfile(@AuthenticationPrincipal CustomUserDetails auth) {
+        //memberId 가져오기
+        Long memberId = auth.getMember().getId();
+
+        MemberResponseDTO.MemberProfileResponse response = memberService.getProfile(memberId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CustomResponse.onSuccess(HttpStatus.OK, response));
+    }
+
+
 
 
 

--- a/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
@@ -99,7 +99,6 @@ public class MemberController {
     )
     public ResponseEntity<CustomResponse<AccessTokenResponseDTO.ReturnTokenDTO>> refreshAccessToken(@RequestBody AccessTokenRequestDTO.CreateAccessTokenDTO dto) {
         //액세스 토큰 재발급
-        System.out.println("1번: " + dto.refreshToken());
         Map<String, String> tokenMap = tokenService.createNewAccessToken(dto.refreshToken());
 
         String newAccessToken = tokenMap.get("accessToken");
@@ -128,6 +127,21 @@ public class MemberController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CustomResponse.onSuccess(HttpStatus.OK, response));
+    }
+
+    @DeleteMapping("/delete")
+    @Operation(
+            summary = "회원 탈퇴 API",
+            description = "회원 탈퇴 API 입니다."
+    )
+    public ResponseEntity<CustomResponse<String>> deleteAccount(@AuthenticationPrincipal CustomUserDetails auth) {
+        //memberId 가져오기
+        Long memberId = auth.getMember().getId();
+
+        memberService.deleteMember(memberId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CustomResponse.onSuccess(HttpStatus.OK, "회원 탈퇴가 완료되었습니다."));
     }
 
 

--- a/src/main/java/com/project/smunionbe/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/smunionbe/domain/member/converter/MemberConverter.java
@@ -1,6 +1,8 @@
 package com.project.smunionbe.domain.member.converter;
 
 import com.project.smunionbe.domain.member.dto.request.MemberRequestDTO;
+import com.project.smunionbe.domain.member.dto.response.MemberClubResponseDTO;
+import com.project.smunionbe.domain.member.dto.response.MemberResponseDTO;
 import com.project.smunionbe.domain.member.entity.Member;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -21,5 +23,14 @@ public class MemberConverter {
                 .major(dto.major())
                 .name(dto.name())
                 .build();
+    }
+
+    public MemberResponseDTO.MemberProfileResponse toMemberProfile(Member member, String studentNumber) {
+        return new MemberResponseDTO.MemberProfileResponse(
+                member.getId(),
+                member.getName(),
+                member.getMajor(),
+                studentNumber
+        );
     }
 }

--- a/src/main/java/com/project/smunionbe/domain/member/dto/request/MemberClubRequestDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/member/dto/request/MemberClubRequestDTO.java
@@ -1,0 +1,7 @@
+package com.project.smunionbe.domain.member.dto.request;
+
+public class MemberClubRequestDTO {
+    public record ChangeNicknameDTO(
+            String newNickname
+    ) {}
+}

--- a/src/main/java/com/project/smunionbe/domain/member/dto/request/MemberRequestDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/member/dto/request/MemberRequestDTO.java
@@ -14,7 +14,13 @@ public class MemberRequestDTO {
             String email,
             String password
     ) {
-
     }
+
+    public record ChangePasswordDTO(
+            String currentPassword,  // 현재 비밀번호
+            String newPassword,      // 새 비밀번호
+            String confirmPassword   // 새 비밀번호 확인
+    ) {}
+
 
 }

--- a/src/main/java/com/project/smunionbe/domain/member/dto/response/MemberResponseDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/member/dto/response/MemberResponseDTO.java
@@ -1,0 +1,10 @@
+package com.project.smunionbe.domain.member.dto.response;
+
+public class MemberResponseDTO {
+    public record MemberProfileResponse(
+            Long id,
+            String name,
+            String major,
+            String studentNumber
+    ) {}
+}

--- a/src/main/java/com/project/smunionbe/domain/member/entity/Member.java
+++ b/src/main/java/com/project/smunionbe/domain/member/entity/Member.java
@@ -40,5 +40,16 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberClub> memberClubs;
+
+
+    //soft delete 수행 메서드
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    //탈퇴한 회원인지 확인
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
 }
 

--- a/src/main/java/com/project/smunionbe/domain/member/entity/Member.java
+++ b/src/main/java/com/project/smunionbe/domain/member/entity/Member.java
@@ -51,5 +51,10 @@ public class Member extends BaseEntity {
     public boolean isDeleted() {
         return deletedAt != null;
     }
+
+    //비밀번호 변경
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }
 

--- a/src/main/java/com/project/smunionbe/domain/member/entity/Member.java
+++ b/src/main/java/com/project/smunionbe/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.project.smunionbe.domain.member.entity;
 
+import com.project.smunionbe.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -16,7 +17,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Table(name = "member")
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/smunionbe/domain/member/entity/MemberClub.java
+++ b/src/main/java/com/project/smunionbe/domain/member/entity/MemberClub.java
@@ -34,5 +34,10 @@ public class MemberClub {
 
     @Column(name = "is_Staff")
     private boolean is_Staff;
+
+    //닉네임 변경 메서드
+    public void updateNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
 }
 

--- a/src/main/java/com/project/smunionbe/domain/member/entity/RefreshToken.java
+++ b/src/main/java/com/project/smunionbe/domain/member/entity/RefreshToken.java
@@ -17,7 +17,8 @@ public class RefreshToken {
     @Column(name = "member_id", nullable = false, unique = true)
     private Long memberId;
 
-    @Column(name = "refresh_token", nullable = false)
+    @Lob
+    @Column(name = "refresh_token", nullable = false, columnDefinition = "TEXT")
     private String refreshToken;
 
     public RefreshToken(Long memberId, String refreshToken) {

--- a/src/main/java/com/project/smunionbe/domain/member/exception/AuthErrorCode.java
+++ b/src/main/java/com/project/smunionbe/domain/member/exception/AuthErrorCode.java
@@ -25,7 +25,15 @@ public enum AuthErrorCode implements BaseErrorCode {
 
     // 로그인 관련 에러
     ALREADY_LOGGED_IN(HttpStatus.BAD_REQUEST, "Auth400_1", "이미 로그인된 상태입니다."),
-    NOT_LOGGED_IN(HttpStatus.BAD_REQUEST, "Auth400_2", "로그인 상태가 아닙니다.");
+    NOT_LOGGED_IN(HttpStatus.BAD_REQUEST, "Auth400_2", "로그인 상태가 아닙니다."),
+
+    // 비밀번호 관련 에러
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "Auth401_1", "현재 비밀번호가 올바르지 않습니다."),
+    PASSWORDS_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "Auth400_3", "새 비밀번호가 일치하지 않습니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "Auth400_4", "비밀번호 형식이 올바르지 않습니다. 비밀번호는 최소 8자 이상이어야 하며, 알파벳과 숫자가 포함된 조합이어야 합니다.");
+
+
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/project/smunionbe/domain/member/exception/AuthErrorCode.java
+++ b/src/main/java/com/project/smunionbe/domain/member/exception/AuthErrorCode.java
@@ -19,6 +19,8 @@ public enum AuthErrorCode implements BaseErrorCode {
 
     // 사용자 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Auth404_0", "존재하지 않는 유저입니다."),
+    MEMBER_ALREADY_DELETED(HttpStatus.NOT_FOUND, "Auth404_1", "이미 탈퇴된 회원입니다."),
+    MEMBER_DELETED(HttpStatus.NOT_FOUND, "Auth404_2", "탈퇴한 계정입니다."),
     INVALID_MEMBER_PASSWORD(HttpStatus.BAD_REQUEST, "Auth400_0", "잘못된 비밀번호입니다."),
 
     // 로그인 관련 에러

--- a/src/main/java/com/project/smunionbe/domain/member/exception/MemberClubErrorCode.java
+++ b/src/main/java/com/project/smunionbe/domain/member/exception/MemberClubErrorCode.java
@@ -10,11 +10,13 @@ import org.springframework.http.HttpStatus;
 public enum MemberClubErrorCode implements BaseErrorCode {
     // 동아리 관련 에러
     MEMBER_CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "MemberClub404_1", "해당 사용자가 가입한 동아리가 없습니다."),
+    MEMBER_CLUB_NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "MemberClub404_5", "해당 사용자가 가입한 동아리가 아닙니다."),
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "MemberClub404_2", "해당 동아리가 존재하지 않습니다."),
     DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "MemberClub404_3", "해당 동아리 부서가 존재하지 않습니다."),
     SELECTED_NOT_FOUND(HttpStatus.NOT_FOUND, "MemberClub404_4", "저장되어 있는 동아리가 존재하지 않습니다."),
     INVALID_MEMBER_CLUB(HttpStatus.BAD_REQUEST, "MemberClub400_2", "사용자가 속해있는 동아리가 아닙니다."),
     DUPLICATE_MEMBER_CLUB(HttpStatus.BAD_REQUEST, "MemberClub400_3", "사용자가 이미 속해있는 동아리입니다."),
+    BLANK_NICKNAME(HttpStatus.BAD_REQUEST, "MemberClub400_4", "닉네임을 입력해주세요."),
 
 
     // 공통 처리

--- a/src/main/java/com/project/smunionbe/domain/member/repository/MemberClubRepository.java
+++ b/src/main/java/com/project/smunionbe/domain/member/repository/MemberClubRepository.java
@@ -28,6 +28,9 @@ public interface MemberClubRepository extends JpaRepository<MemberClub, Long> {
 
     MemberClub findByMemberIdAndClubId(Long memberId, Long clubId);
 
+    @Query("SELECT mc FROM MemberClub mc WHERE mc.member.id = :memberId AND mc.id = :memberClubId")
+    Optional<MemberClub> findByIdAndMemberId(Long memberClubId, Long memberId);
+
     // 멤버가 가입되어 있는 동아리 전체 조회
     List<MemberClub> findAllByMemberId(Long memberId);
 

--- a/src/main/java/com/project/smunionbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/smunionbe/domain/member/repository/MemberRepository.java
@@ -4,10 +4,12 @@ import com.project.smunionbe.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT mc.member FROM MemberClub mc " +

--- a/src/main/java/com/project/smunionbe/domain/member/security/CustomUserDetails.java
+++ b/src/main/java/com/project/smunionbe/domain/member/security/CustomUserDetails.java
@@ -44,7 +44,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
-        return true; // 계정 잠금 여부 로직을 필요에 따라 추가 가능
+        return !member.isDeleted(); //탈퇴한 계정은 로그인 차단
     }
 
     @Override
@@ -54,7 +54,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return member.getDeletedAt() == null; // 계정 활성 여부를 deletedAt 값으로 결정
+        return !member.isDeleted(); //  탈퇴한 계정은 활성화 X
     }
 }
 

--- a/src/main/java/com/project/smunionbe/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/smunionbe/domain/member/service/MemberService.java
@@ -122,6 +122,33 @@ public class MemberService {
         member.delete();
     }
 
+    //비밀번호 변경
+    @Transactional
+    public void changePassword(Long memberId, MemberRequestDTO.ChangePasswordDTO dto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.MEMBER_NOT_FOUND));
+
+        // 현재 비밀번호 검증
+        if (!passwordEncoder.matches(dto.currentPassword(), member.getPassword())) {
+            throw new AuthException(AuthErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 새 비밀번호 유효성 검사
+        if (!dto.newPassword().equals(dto.confirmPassword())) {
+            throw new AuthException(AuthErrorCode.PASSWORDS_DO_NOT_MATCH);
+        }
+
+        // 비밀번호 형식 검사
+        if (dto.newPassword().length() < 8 || !dto.newPassword().matches("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]+$")) {
+            throw new AuthException(AuthErrorCode.INVALID_PASSWORD_FORMAT);
+        }
+
+        // 새로운 비밀번호 암호화 & 저장
+        String encodedPassword = passwordEncoder.encode(dto.newPassword());
+        member.updatePassword(encodedPassword);
+        memberRepository.save(member);
+    }
+
 
 
 }

--- a/src/main/java/com/project/smunionbe/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/smunionbe/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.project.smunionbe.domain.member.service;
 
 import com.project.smunionbe.domain.member.converter.MemberConverter;
 import com.project.smunionbe.domain.member.dto.request.MemberRequestDTO;
+import com.project.smunionbe.domain.member.dto.response.MemberResponseDTO;
 import com.project.smunionbe.domain.member.entity.Member;
 import com.project.smunionbe.domain.member.exception.AuthErrorCode;
 import com.project.smunionbe.domain.member.exception.AuthException;
@@ -85,6 +86,21 @@ public class MemberService {
         }
 
         return member;
+    }
+
+
+    // 회원 프로필 조회
+    @Transactional(readOnly = true)
+    public MemberResponseDTO.MemberProfileResponse getProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.MEMBER_NOT_FOUND));
+
+        return memberConverter.toMemberProfile(member, extractStudentNumber(member.getEmail()));
+    }
+
+    // 이메일에서 학번만 추출
+    private String extractStudentNumber(String email) {
+        return email.split("@")[0];
     }
 
 

--- a/src/main/java/com/project/smunionbe/domain/member/service/MemberService.java
+++ b/src/main/java/com/project/smunionbe/domain/member/service/MemberService.java
@@ -85,6 +85,11 @@ public class MemberService {
             throw new AuthException(AuthErrorCode.INVALID_MEMBER_PASSWORD);
         }
 
+        // 탈퇴한 회원이면 로그인 차단
+        if (member.isDeleted()) {
+            throw new AuthException(AuthErrorCode.MEMBER_DELETED);
+        }
+
         return member;
     }
 
@@ -101,6 +106,20 @@ public class MemberService {
     // 이메일에서 학번만 추출
     private String extractStudentNumber(String email) {
         return email.split("@")[0];
+    }
+
+    // 회원 탈퇴
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.isDeleted()) {
+            throw new AuthException(AuthErrorCode.MEMBER_ALREADY_DELETED);
+        }
+
+        //회원 탈퇴 Soft Delete 수행
+        member.delete();
     }
 
 

--- a/src/main/java/com/project/smunionbe/domain/member/service/TokenService.java
+++ b/src/main/java/com/project/smunionbe/domain/member/service/TokenService.java
@@ -38,7 +38,6 @@ public class TokenService {
 
     // 리프레시 토큰을 기반으로 새로운 액세스 토큰 생성
     public Map<String, String> createNewAccessToken(String refreshToken) {
-        System.out.println("2번: " + refreshToken);
         //토큰 유효성 검사에 실패하면 예외 발생
         if (!tokenProvider.validToken(refreshToken, "refresh")) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);

--- a/src/main/java/com/project/smunionbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/smunionbe/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.project.smunionbe.global.config;
 
+import com.project.smunionbe.domain.member.repository.MemberRepository;
 import com.project.smunionbe.global.config.jwt.TokenAuthenticationFilter;
 import com.project.smunionbe.global.config.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +53,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, MemberRepository memberRepository) throws Exception {
 
         // CORS 정책 설정
         http
@@ -98,7 +99,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()); // 그 외 모든 요청은 인증 필요
 
         http
-                .addFilterBefore(new TokenAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new TokenAuthenticationFilter(tokenProvider, memberRepository), UsernamePasswordAuthenticationFilter.class);
 
 
         return http.build();

--- a/src/main/java/com/project/smunionbe/global/config/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/project/smunionbe/global/config/jwt/TokenAuthenticationFilter.java
@@ -49,6 +49,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                         requestURI.startsWith("/api/v1/users/refresh") ||  //  Access Token 재발급 API 필터링 제외
                         requestURI.startsWith("/api/v1/email/verify"));
 
+
     }
 
     @Override

--- a/src/main/java/com/project/smunionbe/global/config/jwt/TokenProvider.java
+++ b/src/main/java/com/project/smunionbe/global/config/jwt/TokenProvider.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.time.Duration;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -26,6 +27,7 @@ import java.util.Set;
 public class TokenProvider {
     private final JwtProperties jwtProperties;
     private final MemberRepository memberRepository;
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     public String generateAccessToken(Member member, Duration expiredAt) {
         Date now = new Date();
@@ -50,6 +52,7 @@ public class TokenProvider {
                 .setSubject(member.getEmail())
                 .claim("tokenType", tokenType) //accessToken과 refreshToken 구분
                 .claim("id", member.getId())
+                .claim("deletedAt", member.getDeletedAt() != null ? member.getDeletedAt().format(formatter) : null) //탈퇴여부 추가
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
                 .compact();
     }
@@ -107,7 +110,7 @@ public class TokenProvider {
     }
 
     //클레임을 조회해서 반환하는 메서드
-    private Claims getClaims(String token) {
+    public Claims getClaims(String token) {
         return Jwts.parser() //클레임 조회
                 .setSigningKey(jwtProperties.getSecretKey()).build()
                 .parseClaimsJws(token)


### PR DESCRIPTION
# ☝️Issue Number

- #37 

##  📌 개요

- 회원 프로필 조회/회원 탈퇴/비밀번호 변경/동아리 별 닉네임 변경 API 구현하였습니다.
- 테이블 컬럼 수정있어서 만약에 테이블 관련 에러가 나는경우 `ALTER TABLE refresh_token MODIFY COLUMN refresh_token TEXT;`를 입력해주시면 됩니다. JPA 설정에 따라서 에러 유무가 달라질 것 같은데 아마 안 생길것 같긴 합니다!

## 🔁 변경 사항
- 회원 프로필 조회/회원 탈퇴/비밀번호 변경/동아리 별 닉네임 변경 API 구현

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
큰 API들은 이제 얼추 구현 완료했고, 이제 AWS S3를 이용해서 전체적으로 이미지 연동 및 세부적인 코드 수정해주는 작업만 하면 31일까지 마무리 될 것 같습니다!