### PR TITLE
✨feat: 출석 공지 생성 시 설정한 date에 맞게 5분 카운트 난수 생성 & 출석 체크 로직 변경 & 난수 조회 API 개발

### DIFF
--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/controller/AttendanceController.java
@@ -123,4 +123,17 @@ public class AttendanceController {
 
         return CustomResponse.onSuccess("출석이 완료되었습니다.");
     }
+
+    @GetMapping("/{attendanceId}/code")
+    @Operation(summary = "출석 공지 난수 조회 API", description = "특정 출석 공지에 대한 난수를 가져옵니다.")
+    public CustomResponse<String> getAttendanceCode(
+            @PathVariable("attendanceId") Long attendanceId,
+            @AuthenticationPrincipal CustomUserDetails authMember,
+            HttpSession session) {
+
+        Long selectedMemberClubId = clubSelectionService.getSelectedProfile(session, authMember.getMember().getId());
+        String code = attendanceQueryService.getAttendanceCode(attendanceId, selectedMemberClubId);
+
+        return CustomResponse.onSuccess(code);
+    }
 }

--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/dto/request/AttendanceReqDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/dto/request/AttendanceReqDTO.java
@@ -22,7 +22,8 @@ public class AttendanceReqDTO {
     }
 
     public record VerifyAttendanceRequest(
-            Long attendanceId
+            Long attendanceId,
+            String attendanceCode  // 사용자가 입력한 난수
     ){
     }
 }

--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/exception/AttendanceErrorCode.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/exception/AttendanceErrorCode.java
@@ -17,6 +17,8 @@ public enum AttendanceErrorCode implements BaseErrorCode {
     ATTENDANCE_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "AttendanceStatus404_0", "출석 상태를 찾을 수 없습니다."),
     ALREADY_PRESENT(HttpStatus.CONFLICT, "Attendance409_0", "이미 출석이 완료되었습니다."),
     INVALID_STATUS_UPDATE(HttpStatus.BAD_REQUEST, "Attendance400_2", "출석 상태를 업데이트할 수 없습니다."),
+    CODE_EXPIRED(HttpStatus.BAD_REQUEST, "Attendance400_3", "출석 코드가 만료되었습니다."),
+    INVALID_CODE(HttpStatus.BAD_REQUEST, "Attendance400_4", "출석 코드가 유효하지 않습니다."),
 
     // 권한 관련 에러
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "Attendance403_0", "해당 동아리에 접근할 수 없습니다."),

--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/repository/AttendanceStatusRepository.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/repository/AttendanceStatusRepository.java
@@ -1,5 +1,6 @@
 package com.project.smunionbe.domain.notification.attendance.repository;
 
+import com.project.smunionbe.domain.member.entity.MemberClub;
 import com.project.smunionbe.domain.notification.attendance.entity.AttendanceNotice;
 import com.project.smunionbe.domain.notification.attendance.entity.AttendanceStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,6 @@ public interface AttendanceStatusRepository extends JpaRepository<AttendanceStat
     @Query("DELETE FROM AttendanceStatus a WHERE a.attendanceNotice.id = :attendanceNoticeId")
     void deleteAllByAttendanceNoticeId(@Param("attendanceNoticeId") Long attendanceNoticeId);
 
+    // 특정 출석 공지와 멤버 클럽의 출석 상태가 존재하는지 확인
+    boolean existsByAttendanceNoticeAndMemberClub(AttendanceNotice attendanceNotice, MemberClub memberClub);
 }

--- a/src/main/java/com/project/smunionbe/domain/notification/attendance/service/command/AttendanceCommandService.java
+++ b/src/main/java/com/project/smunionbe/domain/notification/attendance/service/command/AttendanceCommandService.java
@@ -13,14 +13,21 @@ import com.project.smunionbe.domain.notification.attendance.exception.Attendance
 import com.project.smunionbe.domain.notification.attendance.repository.AttendanceRepository;
 import com.project.smunionbe.domain.notification.attendance.repository.AttendanceStatusRepository;
 import com.project.smunionbe.domain.notification.fcm.service.event.FCMNotificationService;
+import com.project.smunionbe.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,6 +41,8 @@ public class AttendanceCommandService {
     private final MemberClubRepository memberClubRepository;
     private final AttendanceStatusRepository attendanceStatusRepository;
     private final FCMNotificationService fcmNotificationService;
+    private final RedisUtil redisUtil;
+    private final TaskScheduler taskScheduler;  // 동적 스케줄링
 
     public void createAttendance(AttendanceReqDTO.CreateAttendanceDTO request, Long selectedMemberClubId) {
         // 1. MemberClub 조회 및 운영진 여부 검증
@@ -76,6 +85,9 @@ public class AttendanceCommandService {
 
         // 7. FCM 푸시 알림 전송
         fcmNotificationService.sendPushNotifications(attendanceNotice, targetMembers);
+
+        // 8. 출석 코드 생성 및 스케줄링
+        scheduleRandomCodeGeneration(attendanceNotice);
     }
 
     public void updateAttendance(Long attendanceId, AttendanceReqDTO.UpdateAttendanceRequest request, Long selectedMemberClubId) {
@@ -170,23 +182,62 @@ public class AttendanceCommandService {
     }
 
     public void verifyAttendance(AttendanceReqDTO.VerifyAttendanceRequest request, Long selectedMemberClubId) {
-        // MemberClub 조회
+        // 1. MemberClub 조회
         MemberClub memberClub = memberClubRepository.findById(selectedMemberClubId)
                 .orElseThrow(() -> new AttendanceException(AttendanceErrorCode.MEMBER_NOT_FOUND));
 
+        // 2. AttendanceNotice 조회
         AttendanceNotice attendanceNotice = attendanceRepository.findById(request.attendanceId())
                 .orElseThrow(() -> new AttendanceException(AttendanceErrorCode.ATTENDANCE_NOT_FOUND));
 
+        // 3. Redis에서 난수 조회 및 검증
+        String expectedCode = (String) redisUtil.get("Attendance:Code:" + attendanceNotice.getId());
+        if (expectedCode == null) {
+            throw new AttendanceException(AttendanceErrorCode.CODE_EXPIRED);  // 난수 만료 시
+        }
+
+        if (!expectedCode.equals(request.attendanceCode())) {
+            throw new AttendanceException(AttendanceErrorCode.INVALID_CODE);  // 잘못된 코드 입력 시
+        }
+
+        // 4. AttendanceStatus 조회
         AttendanceStatus attendanceStatus = attendanceStatusRepository.findByAttendanceAndMemberClub(
-                        attendanceNotice.getId(),
-                        memberClub.getId()
-                )
+                        attendanceNotice.getId(), memberClub.getId())
                 .orElseThrow(() -> new AttendanceException(AttendanceErrorCode.ATTENDANCE_STATUS_NOT_FOUND));
 
+        // 5. 이미 출석 체크된 경우 예외 처리
         if (attendanceStatus.getIsPresent()) {
             throw new AttendanceException(AttendanceErrorCode.ALREADY_PRESENT);
         }
 
+        // 6. 출석 상태 업데이트
         attendanceStatus.markPresent();
+        log.info("출석 확인 완료: attendanceId={}, memberClubId={}, memberName={}",
+                attendanceNotice.getId(), memberClub.getId(), memberClub.getMember().getName());
+    }
+
+    private void scheduleRandomCodeGeneration(AttendanceNotice attendanceNotice) {
+        LocalDateTime scheduledTime = attendanceNotice.getDate();
+        long delay = Duration.between(LocalDateTime.now(), scheduledTime).toMillis();  // 예약 시간 계산
+
+        if (delay <= 0) {
+            log.warn("예약 시간이 이미 지났습니다. 즉시 난수 생성");
+            generateAndStoreRandomCode(attendanceNotice);
+            return;
+        }
+
+        taskScheduler.schedule(() -> generateAndStoreRandomCode(attendanceNotice),
+                scheduledTime.atZone(ZoneId.systemDefault()).toInstant());
+        log.info("출석 공지 난수 생성 예약 완료: attendanceId={}, scheduledTime={}", attendanceNotice.getId(), scheduledTime);
+    }
+
+    private void generateAndStoreRandomCode(AttendanceNotice attendanceNotice) {
+        String attendanceCode = generateRandomCode();
+        redisUtil.save("Attendance:Code:" + attendanceNotice.getId(), attendanceCode, (long) 300000, TimeUnit.MILLISECONDS);  // 5분 TTL 설정
+        log.info("출석 공지 난수 생성 및 저장: attendanceId={}, code={}", attendanceNotice.getId(), attendanceCode);
+    }
+
+    private String generateRandomCode() {
+        return String.valueOf((int) (Math.random() * 900000) + 100000);  // 6자리 난수
     }
 }

--- a/src/main/java/com/project/smunionbe/global/config/TaskSchedulerConfig.java
+++ b/src/main/java/com/project/smunionbe/global/config/TaskSchedulerConfig.java
@@ -1,0 +1,18 @@
+package com.project.smunionbe.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class TaskSchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(5);  // 필요한 스레드 개수 설정
+        taskScheduler.setThreadNamePrefix("TaskScheduler-");
+        taskScheduler.initialize();
+        return taskScheduler;
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number

- #51 

##  📌 개요

- 출석 공지 생성 시 설정한 date에 맞게 5분 카운트 난수 생성
- 출석 체크 로직 변경
- 출석 공지 수정 API 로직 리팩토링
- 난수 조회 API 개발

## 🔁 변경 사항
난수는 redis에 저장하는걸로 코드 짰습니다!

## 📸 스크린샷
테스트 완료하였습니다!

## 👀 기타 더 이야기해볼 점