### PR TITLE
🐛️ fix: 가입 되어있는 전체 동아리에서 부서 이름 잘못 반환되는 오류 수정

### DIFF
--- a/src/main/java/com/project/smunionbe/domain/member/converter/MemberClubConverter.java
+++ b/src/main/java/com/project/smunionbe/domain/member/converter/MemberClubConverter.java
@@ -41,7 +41,7 @@ public class MemberClubConverter {
         return memberClubs.stream()
                 .map(memberClub -> {
                     Club club = clubMap.get(memberClub.getClub().getId());
-                    Department department = departmentMap.get(club.getId());
+                    Department department = departmentMap.get(memberClub.getDepartment().getId());
                     return toResponse(memberClub, club, department);
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/project/smunionbe/domain/member/service/MemberClubService.java
+++ b/src/main/java/com/project/smunionbe/domain/member/service/MemberClubService.java
@@ -57,8 +57,8 @@ public class MemberClubService {
         }
 
         // Department 조회 및 매핑
-        Map<Long, Department> departmentMap = clubMap.values().stream()
-                .map(Club::getId)
+        Map<Long, Department> departmentMap = memberClubs.stream()
+                .map(memberClub -> memberClub.getDepartment().getId())
                 .distinct()
                 .collect(Collectors.toMap(
                         id -> id,


### PR DESCRIPTION
# ☝️Issue Number

- #56 

##  📌 개요

-🐛️ fix: 가입 되어있는 전체 동아리에서 부서 이름 잘못 반환되는 오류 수정

## 🔁 변경 사항
가입 되어있는 전체 동아리에서 부서 이름 잘못 반환되는 오류 수정

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점