### PR TITLE
✨ feat: 비밀번호 찾기 기능 추가 & 탈퇴한 회원 재가입 예외 처리

### DIFF
--- a/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/smunionbe/domain/member/controller/MemberController.java
@@ -213,5 +213,17 @@ public class MemberController {
                 .body(CustomResponse.onSuccess(HttpStatus.OK, "프로필 사진이 삭제되었습니다."));
     }
 
+    @PostMapping("/find-password")
+    @Operation(
+            summary = "비밀번호 찾기 API",
+            description = "등록된 이메일로 임시 비밀번호를 전송합니다."
+    )
+    public ResponseEntity<CustomResponse<String>> findPassword(@RequestBody @Valid MemberRequestDTO.FindPasswordDTO dto) {
+        memberService.findPassword(dto);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CustomResponse.onSuccess(HttpStatus.OK, "임시 비밀번호가 이메일로 전송되었습니다."));
+    }
+
+
 
 }

--- a/src/main/java/com/project/smunionbe/domain/member/dto/request/MemberRequestDTO.java
+++ b/src/main/java/com/project/smunionbe/domain/member/dto/request/MemberRequestDTO.java
@@ -22,5 +22,9 @@ public class MemberRequestDTO {
             String confirmPassword   // 새 비밀번호 확인
     ) {}
 
+    public record FindPasswordDTO(
+            String email
+    ) {}
+
 
 }

--- a/src/main/java/com/project/smunionbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/smunionbe/global/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
             "/api/v1/users/signup", //회원가입은 인증이 필요하지 않음
             "/api/v1/users/login", //로그인은 인증이 필요하지 않음
             "/api/v1/users/refresh", //accessToken 재발급은 인증이 필요하지 않음
+            "/api/v1/users/find-password",
     };
 
     @Bean //인증 관리자 관련 설정

--- a/src/main/java/com/project/smunionbe/global/config/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/project/smunionbe/global/config/jwt/TokenAuthenticationFilter.java
@@ -53,6 +53,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                         requestURI.startsWith("/api/v1/users/signup") ||
                         requestURI.startsWith("/api/v1/users/login") ||
                         requestURI.startsWith("/api/v1/users/refresh") ||  //  Access Token 재발급 API 필터링 제외
+                        requestURI.startsWith("/api/v1/users/find-password") ||
                         requestURI.startsWith("/api/v1/email/verify"));
 
 

--- a/src/main/resources/templates/EmailTemporaryPasswordTemplate.html
+++ b/src/main/resources/templates/EmailTemporaryPasswordTemplate.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>임시 비밀번호 발급</title>
+</head>
+<body>
+<p style="font-size:10pt; font-family:sans-serif; padding:0 0 0 10pt"><br><br></p>
+<div style="width:440px; margin:30px auto; padding:40px 0 60px; background-color:#fff; border:1px solid #ddd; text-align:center; font-size:16px; font-family:malgun gothic,serif;">
+    <h3 style="font-weight:bold; font-size:20px; margin:28px auto;">임시 비밀번호 발급</h3>
+    <div style="width:200px; margin:28px auto; padding:8px 0 9px; background-color:#f4f4f4; border-radius:3px;">
+        <span style="display:inline-block; vertical-align:middle; font-size:13px; color:#666;">안녕하세요, </span>
+        <span style="display:inline-block; margin-left:16px; vertical-align:middle; font-size:21px; font-weight:bold; color:#4d5642;" th:text="${name} + '님!'"></span>
+    </div>
+    <p>요청하신 임시 비밀번호는 아래와 같습니다:</p>
+    <h3 style="color: #2E86C1;">
+        <span style="display:inline-block; margin-left:16px; vertical-align:middle; font-size:21px; font-weight:bold; color:#4d5642;" th:text="${temporaryPassword}"></span>
+    </h3>
+    <p>보안을 위해 로그인 후 꼭 비밀번호를 변경해주세요.</p>
+    <br>
+    <p>감사합니다.</p>
+    <p>Smunion 팀 드림</p>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
# ☝️Issue Number

- #58

##  📌 개요

- ✨ feat: 비밀번호 찾기 기능 추가 & 탈퇴한 회원 재가입 예외 처리

## 🔁 변경 사항
아래 스크린샷 사진 처럼 비밀번호 변경 신청시 가입한 이메일로 임시 비밀번호 코드가 옵니다.
거기에 탈퇴한 회원을 soft delete로 구현하여 탈퇴한 회원도 DB에 남아있는데, 재가입 시 이미 존재하는 이메일이라고 뜨는 오류 해결하였습니다!

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/9949416b-1845-4391-a57e-c66742761218)


## 👀 기타 더 이야기해볼 점